### PR TITLE
User exit doc gill review

### DIFF
--- a/docs/Intro20-User-Exit_Routines.md
+++ b/docs/Intro20-User-Exit_Routines.md
@@ -300,85 +300,10 @@ Exits must be written following the GenevaERS User Exit guidelines.   These spec
     - An End of File on for a Read exit, or 
     - Write the standard extract record, Write a different record and then return to the exit for processing, or Skip the extract record and continue processing for Write Exits
 
-All Exits may signal view or process level errors as well
+All Exits may signal view or process level errors as well.
 
-The following are the data structures involved:
+More details about how to create a user exit can be found in the [User Exit Programming Guide](UserExitGuide.md)
 
-##  Phase Codes
-```
-  01  X95PARM1-ENV-DATA.
-
-       05  X95PARM1-THREAD-NBR         PIC S9(04)  COMP.
-
-       05  X95PARM1-PHASE-CODE         PIC  X(02).
-
-           88  X95PARM1-OPEN-PHASE     VALUE 'OP'.
-
-           88  X95PARM1-READ-PHASE     VALUE 'RD'.
-
-           88  X95PARM1-CLOSE-PHASE    VALUE 'CL'.
-
-       05  X95PARM1-CURRENT-VIEW-ID    PIC S9(09)  COMP.
-
-  *During The Open Phase, Read Exits Should 
-
-  *Return The First Event Record.
-```
-
-##  Pointers
-```  
-  X95PARM2-PROCESS-DATE-TIME
-
-  X95PARM3-STARTUP-DATA
-  
-  X95PARM4-EVENT-REC
-  
-  X95PARM5-EXTRACT-REC
-  
-  X95PARM6-LOOKUP-KEY (join values)
-  
-  X95PARM7-WORK-AREA-ANCHOR
-
-  X95PARM8-RETURN-CODE
-
-  X95PARM9-RESULT-PTR
-
-  X95PARMA-RESULT-BLOCK-SIZE`
-```
-##  Return Codes
-```
-     01  X95PARM8-RETURN-CODE        PIC S9(09)  COMP.
-
-  *  All Exits:
-
-       88  X95PARM8-SUCCESSFUL             VALUE +0.
-
-  *  Lookup Exits Only:
-
-       88  X95PARM8-NOT-FOUND              VALUE +4.
-
-  *  Write Exits Only:
-
-       88  X95PARM8-WRITE-AND-REPEAT-CALL  VALUE +4.
-
-  *  READ EXITS ONLY:
-
-       88  X95PARM8-END-OF-FILE            VALUE +8.
-
-  *  LOOKUP EXITS ONLY:
-
-       88  X95PARM8-SKIP-EVENT-REC         VALUE +8.
-
-  *  WRITE EXITS ONLY: 
-
-       88  X95PARM8-SKIP-EXTRACT-REC       VALUE +8.
-
-  *  ALL EXITS:
-
-       88  X95PARM8-DISABLE-CURRENT-VIEW   VALUE +12.
-
-       88  X95PARM8-ABORT-RUN              VALUE +16.
-```
 <div style="clear: right" >
 
 ## GenevaERS Standard Sort Exit

--- a/docs/Intro20-User-Exit_Routines.md
+++ b/docs/Intro20-User-Exit_Routines.md
@@ -20,66 +20,54 @@ In this page, we examine the following Logic Table Functions:
 
 <div style="clear: right" >
 
-# GenevaERS Scan Performance Engine
-
-<img style="float: right;" width="50%" vspace="5" alt="GenevaERS Scan Performance Engine" src=images/Module20-User-Exit_Routines/Module20_Slide4.jpeg title="GenevaERS Scan Performance Engine"/>
+# GenevaERS Performance Engine
 
 Let’s briefly review the GenevaERS Performance Engine processes.
 
 <div style="clear: right" >
 
-## Metadata and View Creation, and the GenevaERS Repository
+## Metadata and View Creation
 
-<img style="float: right;" width="50%" vspace="5" alt="Metadata and View Creation, and the GenevaERS Repository" src=images/Module20-User-Exit_Routines/Module20_Slide5.jpeg title="Metadata and View Creation, and the GenevaERS Repository"/>
-
-GenevaERS begins by developers creating metadata describing records, files, fields, relationships between files and fields, and user exits which might be called to perform processing in the workbench.  They then create views, which specify the logic to be applied to the data through the scan processes.  The metadata and the views are stored in the GenevaERS View and Metadata repository, awaiting the start the Performance Engine.
+GenevaERS begins by developers creating metadata describing records, files, fields, relationships between files and fields, and user exits which might be called to perform processing in the Workbench.  They then create views, which specify the logic to be applied to the data through the scan processes.  The metadata and the views are managed in the GenevaERS repository using the Workbench, then exported into an XML format, awaiting the start the Performance Engine. The exported XML files can be managed using any source control tool, if required.
 
 <div style="clear: right" >
 
-## Select, Logic and Reference File Phases
+## Run Control Phase
 
-<img style="float: right;" width="50%" vspace="5" alt="Select, Logic and Reference File Phases" src=images/Module20-User-Exit_Routines/Module20_Slide6.jpeg title="Select, Logic and Reference File Phases"/>
+The first part of the Performance engine creates the files required for the reference phase and the extract phase.  It reads the data provided in the GenevaERS XML files, performs optimization logic, then creates a VDP, View Definition Parameter file, a JLT, Join Logic Table, and XLT, Extract Logic Table. The JLT is required for the Reference File Phase, and the XLT for the Extract Phase. The logic tables contain the functions codes described in this and the prior pages.
 
-The first parts of the Performance engine performs the Select, Logic and Reference File phases.  The Select Phase selects the views and associated metadata for those views from the View and Metadata Repository.  Alternatively, this phase can read data provided in a GenevaERS XML schema, which defines the metadata and functions to be performed against the data.  It bundles either of these into a VDP, View Definition Parameter file.
+<div style="clear: right" >
 
-The VDP is used in the Logic Phase to produce two Logic Tables, one for the Reference File Phase, and one for the Extract Phase.  The logic tables contain the functions codes described in this and the prior pages.  
+## Reference Phase
 
-The Extract Phase Logic Table file is used to process event files, but before that the Reference File Logic Table is used to extract a core image file from the reference files.  The Reference File Logic Table does not contain any selection logic, thus it does not remove any rows of data.  Rather, the core image file contains only those fields (columns) needed to be loaded into memory for joins, plus the keys required for the join processes and any effective dates.
+The Reference File Logic Table is used to extract a core image file from the reference files.  The Reference File Logic Table does not contain any selection logic, thus it does not remove any rows of data.  Rather, the core image file contains only those fields needed to be loaded into memory for lookups, plus the keys required for the lookup processes and any effective dates.
 
 <div style="clear: right" >
 
 ## Extract Phase
 
-<img style="float: right;" width="50%" vspace="5" alt="Extract Phase" src=images/Module20-User-Exit_Routines/Module20_Slide7.jpeg title="Extract Phase"/>
+The Extract Phase begins by loading the VDP, Extract Phase Logic Table and Reference Data from disk.  It then uses the logic table to generate highly optimized reenterant machine code. It opens the output (extract) files. It opens the source files, each one in a new thread, and executes these threads in parallel.  Each source file record is read and processed through the logic table, performing lookups, functions, and calling user exits as required, then writing data to the output extract files. 
 
-The Extract Phase begins by loading the VDP, Extract Phase Logic Table and Reference Data from disk.  It then uses the logic table to generate machine code for each thread, each input file partition. It then opens input and output files, and executes these threads according to the thread governor, in parallel.  Each event file record is read and processed through the logic table, performing joins, and writing selected data to output extract files. 
-
-The Extract Phase includes multiple types of user exits, including read, write and look-up exits, highlighted on this graphic by the green balls.
+The Extract Phase includes multiple types of user exits, including read, write and look-up exits.
 
 <div style="clear: right" >
 
 ## Format Phase
 
-<img style="float: right;" width="50%" vspace="5" alt="Format Phase" src=images/Module20-User-Exit_Routines/Module20_Slide8.jpeg title="Format Phase"/>
-
 The format phase, which is optional depending on the view requirements, begins by sorting each extract file using a custom generated sort card based upon the sort criteria of the views written to that extract file.  During the final phase of sort processing—that which writes data to disk—the records are passed in memory to the format engine.  These records are formatted according to the VDP specifications.  The data is written to the final output file.
 
-The Format Phase includes the Format Exit, shown here at the end of the Format process.  Sort utilities also allow creating sort input exits, shown here over the Sort process.
-
-Let’s overview each of these users exits.
+The Format Phase includes the Format Exit.  Sort utilities also allow creating sort input exits.
 
 <div style="clear: right" >
 
 # User Exit Overview
-
-<img style="float: right;" width="50%" vspace="5" alt="User Exit Overview" src=images/Module20-User-Exit_Routines/Module20_Slide9.jpeg title="User Exit Overview"/>
 
 User exits, which can also be thought of as API points, are custom programs to perform functions GenevaERS does not do natively.  For example, GenevaERS does not perform an exponential mathematical calculation.  A customer could create a program to perform this function, and call it from GenevaERS to return the results of the calculation.
 
 As noted, GenevaERS has four major points which can invoke a user exit, read, lookup, write and format exits.  The first three are Extract Phase exits, and are used much more frequently than the fourth Format Phase exit.  They are:
 
 - Read Exits stand between the actual input event file and the GenevaERS views.  These exits can modify input records to be presented to GenevaERS threads for processing. 
-- Lookup Exits stand between GenevaERS views and the look-up data loaded into memory.   Lookup exits accept join parameters and return looked up records in response to individual joins. These exits can also be used as simple function calls which do not actually perform any look-up.  For example the exponential calculation discussed above could be written as a look-up exit.
+- Lookup Exits stand between GenevaERS views and the look-up data loaded into memory.  Lookup exits accept lookup parameters and return looked up records in response to individual lookups. These exits can also be used as simple function calls which do not actually perform any lookup.  For example, the exponential calculation discussed above could be written as a lookup exit.
 - Write Exits stand between GenevaERS and the extract files.  They receive extract records and can manipulate them before being written to extract files.  
 - Format Exits, the only GVBMR88 exit, accepts summarized and formatted Format Phase output records prior to being written to files. Format exits are very similar to write exits, except that the record used is the final output record, rather than the extract record.  
 
@@ -89,151 +77,127 @@ At the end of this page we will touch on a non-GenevaERS exit, the Sort Input Ex
 
 ## Read Exit Functionality
 
-<img style="float: right;" width="50%" vspace="5" alt="Read Exit Functionality" src=images/Module20-User-Exit_Routines/Module20_Slide10.jpeg title="Read Exit Functionality"/>
-
-As noted, read exits sit between the extract engine, and the input event file.  The GenevaERS views, inside GVBMR95, are only aware of the virtual file which is output by the read exit.  Read Exits are assigned to a physical file, and are placed on the RENX logic table function.  It is called each time the RENX function is executed.  
+Read exits sit between the extract engine, and the input source file. The GenevaERS generated machine code satisfying the views, is only aware of the virtual file which is output by the read exit. Read Exits are assigned to a physical file, and are associated with the REEX logic table function.
 
 Examples of read exits that have been written for GenevaERS applications include:
-- Read a specialized database structure and extract every record to be passed to GenevaERS to allow GenevaERS to produce reports against those records
+- Read a specialized database structure and extract records to be passed to GenevaERS
 - Merge multiple sequential files and compare snap shot records with the history file into a single master file, then used to produce reports
 - Process sets of records, and perform functions across the entire set, where one record can affect other either later, or earlier records.  GenevaERS does not easily perform these functions in view.  After all affects are determined and applied, the file is passed to GenevaERS for report generation.
 
-Read exits are typically the most complex to write, because they must perform some IO of some kind.  They are further complicated because it is very inefficient to call a read exit for each record; so instead they are usually written to do block level processing.  
+Read exits are typically the most complex to write, because they must perform some IO of some kind.  They are further complicated because it is very inefficient to call a read exit for each record; so instead they are usually written to do block level processing.
 
 <div style="clear: right" >
 
 ## Look-up Exits Functionality
 
-<img style="float: right;" width="50%" vspace="5" alt="Look-up Exits Functionality" src=images/Module20-User-Exit_Routines/Module20_Slide11.jpeg title="Look-up Exits Functionality"/>
+Lookup exits sit between the extract engine, and a potential lookup file. The GenevaERS views are only aware of the virtual lookup record returned by the lookup exit. A sample application could be doing direct reads to a database table to retrieve a reference value for processing.  However, most often lookup exits do not actually load any data from disk; rather they simply use input parameters passed to them by the views to do some function. Thus the exit is basically a simple function call.  
 
-Look-up exits sit between the extract engine, and a potential look-up file. The GenevaERS views are only aware of the virtual lookup record output by the lookup exit.  A sample application could be doing direct reads to a database table to retrieve a join value for processing.  However, most often look-up exits do not actually load any data from disk; rather they simply use input parameters passed to them by the views to do some function.  Thus the exit is basically a simple function call.  
+Look-up exits are the easiest type of exit to create. The parameters passed to the lookup exit are the values placed in the fields of the lookup key. These can be constants, fields from the event file, or fields from another lookup, including calls to other exits. The output from the lookup exit is a record that must match the LR for the “reference file” record it is to return.  Although it appears to a GenevaERS developer as if GenevaERS has taken the keys and performed a search of a reference table to find the appropriate record, the exit may have done no such thing.  In fact, it could do something as simple as reordering the fields passed to it and returning the record.
 
-Look-up exits are the easiest type of exit to create. The parameters passed to the lookup exit are the values placed in the fields of the join key.  These can be constants, fields from the event file, or fields from another lookup, including calls to other exits.  The output from the lookup exit is a record that must match the LR for the “reference file” record it is to return.   Although it appears to a GenevaERS developer as if GenevaERS has taken the keys and performed a search of a reference table to find the appropriate record, the exit may have done no such thing.  In fact, it could do something as simple as reordering the fields passed to it and returning the record.
-
-Lookup Exits are assigned to a target look-up LR.  When used, the typical LUSM functions are changed to LUEX functions.   The exit is called each time the LUEX function is executed.  
-
-Certain pages are delivered with the product, called GenevaERS Standard Look-up Exits.  These perform a common set of functions not done by native GenevaERS.   For example:
-- GVBXLEXP	An exponential calculator.  If passed a number, format and exponent, it will perform the calculation
-- GVBXLMD	Accepts two dates, and computes days between those dates
-- GVBXLRUD	Simply returns the GenevaERS Fiscal Year data, passed in through the VDP
-- GVBXLST	Accepts strings and concatenates them and returns a single string value
-- GVBXLTM	Performs a trim function against passed string parameters
+Lookup Exits are assigned to a target lookup LR.  When used, the typical LUSM functions are changed to LUEX functions. The exit is called each time the LUEX function is executed.
 
 <div style="clear: right" >
 
-## Write and Format Exit Functionality
+## Write Exit Functionality
 
-<img style="float: right;" width="50%" vspace="5" alt="Write and Format Exit Functionality" src=images/Module20-User-Exit_Routines/Module20_Slide12.jpeg title="Write and Format Exit Functionality"/>
+Write exits sit between the extract engine, and a potential extract or output file. Each write exit is tightly coupled to it’s GenevaERS view, because the exit receives the view output. Extract exits are called whenever a view is to write an extract record. In addition to the view’s extract record the write exit has access to the current source record. 
 
-Write exits sit between the extract engine, and a potential extract or output file. Each write exit is tightly coupled to it’s GenevaERS view, because the exit receives the view output.  Extract exits are called whenever a view is to write an extract record.  In addition to the view’s extract record the write exit is also passed and can sees the event record.  
-
-Write Exits are associated with a view, since the view or a write statement within the view generates the WREX logic table function (rather than WRIN, WRDT, or WRSU functions) and creates the extract record 
+Write exits are defined in the WRITE statement within a view.
 
 The write exit can tell GVBMR95 to do any one of the following:
-- Tell GVBMR95 to write a record the exit specifies (could be any record) and continue with event file processing
+- Tell GVBMR95 to write a record the exit specifies (could be any record), and continue with source file processing
 - Tell GVBMR95 to skip this extract record and go on
 - Tell GVBMR95 to write a record the exit specifies (could be any record) and return to the exit to do more processing
 
-The exit can manipulate the extract record; substitute a new record, table the extract record in some way and then dump the table at the end of event file processing, or any other number of things.  Note, though, that unlike read exits which do open and actually read files, write exits typically do not.  They return records to GenevaERS to write to the extract file.  They could do their own IO, but there is typically no benefit to doing so.  GenevaERS’s write routines are very efficient.
+The exit can manipulate the extract record; substitute a new record, table the extract record in some way and then dump the table at the end of source file processing, or any other number of things. Note, though, that unlike read exits which do open and actually read files, write exits typically do not. They return records to GenevaERS to write to the extract file. They could do their own IO, but there is typically no benefit to doing so. GenevaERS’s write routines are very efficient.
 
 Some examples of write exits include the following:
 - Table multiple records, summarize them if they have common sort keys, and write a record when the key changes. 
-- Read a set of parameters giving scoring requirements, table multiple records and upon a key change, score records.  Create a completely new record with the scoring results, write this new record, and drop all the tabled records
+- Read a set of parameters giving scoring requirements, table multiple records and upon a key change, score records.  Create a completely new record with the scoring results, write this new record, and drop all the tabled records.
   
-Write exits are in between read and lookup exits for complexity.  This is mainly because of the complexity of dealing with extract records.  The exit must know what the extract record will look like for a particular view.  This might be easiest to determine by actually writing the view, and inspecting the extracted records to find positions and lengths.  Any changes in the views can create a new to update the write exit.  
+Write exits are in between read and lookup exits for complexity. Write exits must know what the extract record will look like for a particular view. A LR representing the output of a view can be generated using the Workbench.
 
-Format exits are very much like write exits, except that they are called at the end of GVBMR88.  They are also dependent upon the view specification.  They are called for each format output record.  Like write exits, they are specified on each view.  They are specified only in the VDP; there is no logic table impact for them.
+<div style="clear: right" >
+
+## Format Exit Functionality
+
+Format exits are very much like write exits, except that they are called at the end of GVBMR88. They are also dependent upon the view specification.  They are called for each format output record.  Like write exits, they are specified on each view. They are specified only in the VDP; there is no logic table impact for them.
 
 <div style="clear: right" >
 
 ## Metadata Setup
 
-<img style="float: right;" width="50%" vspace="5" alt="Metadata Setup" src=images/Module20-User-Exit_Routines/Module20_Slide13.jpeg title="Metadata Setup"/>
+### User-Exit Routine
 
-Using exits requires that they first be described in the User Exit Routine screens within the Workbench.  The name can be anything desired. The type can be either Read, Look-up, Write, or Format.  The language and path are for documentation only.  The executable must match the load page name stored within an accessible loadlib for either GVBMR95 or GVBMR88. 
+Exits require a definition that can be added using the User Exit-Routine screens within the Workbench. The name can be anything desired. The type can be either Read, Lookup, Write, or Format. The language must be defined. The executable must match the load page name stored within an accessible loadlib for either GVBMR95 or GVBMR88. 
+The Optimizable flag is only applicable for lookup exits. Remember that GenevaERS bypasses certain lookups when the lookup has already been performed. In these cases, the look-up exit would not be called in the subsequent cases. If the lookup exit is stateless, in other words, it does not function differently from one execution to another given the same input parameters, the exit can be optimized. If the exit retains its state from one call to another, then it must be called each time and cannot be optimized.
 
-<div style="clear: right" >
-
-<img style="float: right;" width="50%" vspace="5" alt="Metadata Setup" src=images/Module20-User-Exit_Routines/Module20_Slide14.jpeg title="Metadata Setup"/>
-
-The Optimizable flag is only applicable for look-up exits.  Remember that GenevaERS bypasses certain look-ups when the look-up has already been performed.  In these cases, the look-up exit would not be called in the subsequent cases.  If the look-up exit is stateless, in other words, it does not function differently from one execution to another given the same input parameters, the exit can be optimized.  If the exit retains its state from one call to another, then it must be called each time and cannot be optimized.  
-
-For example, one exit was written to detect the first time it was called for a particular event file record.  In this case, it would return a return code of 0; every subsequent call would return a code of 1.  This exit cannot be optimized; each potential call must actually call the exit.  Otherwise the exit would always return a code of 0.
+For example, one exit was written to detect the first time it was called for a particular event file record. In this case, it would return a return code of 0; every subsequent call would return a code of 1. This exit cannot be optimized; each potential call must actually call the exit.  Otherwise the exit would always return a code of 0.
 
 <div style="clear: right" >
 
-# Metadata Set-up 
+### Read Exits
 
-## Read Exits
+Once the user exits are entered into the User Exit table, they can be assigned to the other appropriate metadata components. For Read Exits, the exit must be assigned to specific Physical File entities.
 
-<img style="float: right;" width="50%" vspace="5" alt="Metadata Set-up Read Exits" src=images/Module20-User-Exit_Routines/Module20_Slide15.jpeg title="Metadata Set-up Read Exits"/>
-
-Once the user exits are entered into the User Exit table, they can be assigned to the other appropriate metadata components.  For Read Exits, the exit must be assigned to specific Physical File entities.  Remember that for each physical file read by views being processed, the Logic Table contains an RENX logic table row for that physical file.  By assigning a read exit on the physical file, the generated RENX entry will contain the exit to be called each time a new record or block of data is needed
-
-The data returned by the read exit must match the Logical Records that are assigned to this physical file.  Thus when a view accesses a field to perform, perhaps, a selection function, the data must match the logical record layout for the GenevaERS “physical” file entity, not the file read by the read exit.
+The data returned by the read exit must match the Logical Records that are associated with this physical file.
 
 <div style="clear: right" >
 
-## Look-up Exits
+### Look-up Exits
 
-<img style="float: right;" width="50%" vspace="5" alt="Look-up Exit LR" src=images/Module20-User-Exit_Routines/Module20_Slide16.jpeg title="Look-up Exit LR"/>
+Standard lookups require the data that is referenced to be defined by an LR. For lookup exits, the data to be returned by the exit must also match a specific LR, and it is in this LR definition that the Lookup User-Exit routine is defined. Select the LR Properties tab, then select the appropriate User-Exit Routine from the drop down list. You can also specify Parameter data that will be passed to the Lookup User-Exit Routine.
 
-Standard look-ups require the data to be joined to be defined by an LR.  For look-up exits, the logical record to be returned by the exit must match a specific LR (not the data read from file by the look-up exit, if there is any).  In the example shown here, the “phase code” value must be returned by the look-up exit in position 3 for a length of 2.
+When defining the logical record fields to be returned by the exit in the LR Fields tab, define any of the fields the exit will require as “keys,” as if the exit were going to search a reference file table to find the required answer. 
 
-When defining the logical record to be returned by the exit, define any of the input parameters the exit will require as “keys,” as if the exit were going to search a reference file table to find the required answer. 
-
-Next define a path that will provide the needed inputs to the exit.  The values in the path can be provided as constants in the views, or in the path, or as values passed from the input file or looked up from another look-up table, requiring a multi-level look-up.
+Next define a path that will provide the needed inputs to the exit (keys). The values in the path can be provided as constants in the views, or in the path, or as values passed from the source file or looked up from another reference table, requiring a multi-level look-up.
 
 <div style="clear: right" >
 
-<img style="float: right;" width="50%" vspace="5" alt="Look-up Exit LR" src=images/Module20-User-Exit_Routines/Module20_Slide17.jpeg title="Look-up Exit LR"/>
+### Write Exits
 
-After defining the LR and the look-up path, to assign a lookup exit to the Logical record, select the LR Properties tab.  Then select the appropriate exit.  When a field from the target LR is used in a view, this exit will be called to return data in the format of the defined logical record.  Thus when the Logic Table is generated, the LUSM will be changed to LUEX.  This logic table function contains the user page name to be called.
+Write Exits are assigned in WRITE statements.
 
-<div style="clear: right" >
+Write exits do not return data to GenevaERS views; therefore no logical record defines the outputs from these exits. The view columns define what this exit will receive, so changes to the view layout will affect write exits.
 
-## Write and Format Exits
+### Format Exits
 
-<img style="float: right;" width="50%" vspace="5" alt="Write and Format Exits" src=images/Module20-User-Exit_Routines/Module20_Slide18.jpeg title="Write and Format Exits"/>
+Format User-Exits are assigned in view properties on the Format Phase tab.  
 
-Write Exits and Format Exits are assigned in view properties.  Write exits are assigned in the Extract Phase tab; Format Exit are assigned Format Phase tab.  
-
-Because both of these exits sit potentially at the end of the process, these exits do not return data to GenevaERS views; therefore no logical record defines the outputs from these exits.  Rather the view columns and format (file, hardcopy, etc.) define what these exits will receive.  Changes to the view layout will affect the exits.
-
-Often the “Write DT Area” option is used with write exits, to eliminate the complexity of the extract record layout.  Only the column data is passed to the write exit.
+Again no logical record defines the outputs from Format User-exits. The view columns and format (file, hardcopy, etc.) define what these exits will receive.  Changes to the view layout will affect the exit.
 
 <div style="clear: right" >
 
 ## Start-up (“Fixed”) Parameters
 
-<img style="float: right;" width="50%" vspace="5" alt="Start-up (“Fixed”) Parameters" src=images/Module20-User-Exit_Routines/Module20_Slide19.jpeg title="Start-up (“Fixed”) Parameters"/>
-
 Each exit has the potential to receive a fixed set of parameters upon start up.  These parameters are assigned for each instance that an exit is invoked.  
 
-For example, a look-up exit may function differently depending on which LR it is supposed to return; perhaps data can be returned in compressed format in one instance, and not in another.  The LR for the compressed data may pass in a start-up parameter of “CMPSD” and the uncompressed LR would pass in a start-up parameter of “UNCMPSD”.  In this way the same exit program can be used, and which LR should be returned can be indicated as a parameter to the exit.  
+For example, a lookup exit may function differently depending on which LR it is supposed to return; perhaps data can be returned in compressed format in one instance, and not in another.  The LR for the compressed data may pass in a start-up parameter of “CMPSD” and the uncompressed LR would pass in a start-up parameter of “UNCMPSD”.  In this way the same exit program can be used, and which LR should be returned can be indicated as a parameter to the exit.  
+
 
 <div style="clear: right" >
 
-## Look-up Exit Parameters
+## Exit Parameters
 
-<img style="float: right;" width="50%" vspace="5" alt="Look-up Exit Parameters" src=images/Module20-User-Exit_Routines/Module20_Slide20.jpeg title="Look-up Exit Parameters"/>
+Read exits receive only the start-up parameters.  
 
-Read exits receive only the start-up parameters.  Write and Format exits also receive start-up parameters; they also receive the extracted record from the view.  Write exits also have visibility to the event file record as well.
+Write and Format exits also receive start-up parameters; they also receive the extracted record from the view.  
 
-Look-up exits, by contrast, receive start-up parameters; they also have visibility to the event file record.  Additionally, Look-up exits receive all the parameters built in the look-up path.  These values must match the required key for the logical record.
+Write exits also have visibility to the source file record.
+
+Lookup exits, receive start-up parameters; they also have visibility to the source file record. Additionally, Lookup exits receive all the parameters built in the lookup path. These values must match the required key for the logical record.
 
 Note the difference between these two types of parameters: 
 - The start-up parameters do not change throughout the entire run of GenevaERS.  They are constant.  They are typically only used by the exit at start up to determine which mode the program should function in.
-- The look-up key values can change based upon every event file record processed.  Customer ID 1 on the first record may become Customer ID 10,000 on the next record.  
+- The lookup key values can change based upon every source file record processed.  Customer ID 1 on the first record may become Customer ID 10,000 on the next record.  
 
 <div style="clear: right" >
 
-# Look-up Exit Example View
+# Lookup Exit Example View
 
 <img style="float: right;" width="50%" vspace="5" alt="Example View" src=images/Module20-User-Exit_Routines/Module20_Slide21.jpeg title="Example View"/>
 
-We will use this view to show the GVBMR95 Logic Table and MR95 Trace.  Our example will use a look-up exit, which returns various thread parameters that can be of interest for technical reasons in a view.  The look-up exit is assigned on the LR and path we just examined.
-
+We will use this view to show the GVBMR95 Logic Table and MR95 Trace.  Our example will use a lookup exit, which returns various thread parameters that can be of interest for technical reasons in a view.  The lookup exit has been assigned on the LR and path.
 
 <div style="clear: right" >
 
@@ -243,8 +207,6 @@ This is the logic table for the example view.  Note that lookups, which would no
 
 Our path required a single character value be passed to the exit.  This “key” value—a constant of “D”—built by the LKC function, will be passed to the exit as part of the lookup.
 
-Note also that the view has no write exit, because the logic table is WRXT, not a WREX.  Also note there is no Exit ID assigned to the WRXT row.
-
 <div style="clear: right" >
 
 ## Not Optimized
@@ -253,9 +215,9 @@ Note also that the view has no write exit, because the logic table is WRXT, not 
 
 This is the GVBMR95 Trace for the logic table.  
 
-For event file record 1, the LKC function builds a key with a value “D” in it.  This value is passed to the exit GVBXLENV during the LUEX function.  The exit is called.  The view then uses the data, through a DTL function, placing a value 0001 into column 2.  GVBXLENV did not search any data.  It simply queried the GenevaERS thread number to return a value of 0001.  
+For source file record 1, the LKC function builds a key with a value “D” in it.  This value is passed to the exit GVBXLENV during the LUEX function.  The exit is called.  The view then uses the data, through a DTL function, placing a value 0001 into column 2.  GVBXLENV did not search any data.  It simply queried the GenevaERS thread number to return a value of 0001.  
 
-Also, note the number of times the exit is called in this trace.  Each lookup actually required calling the exit.
+Note the number of times the exit is called in this trace.  Each lookup actually required calling the exit.
 
 <div style="clear: right" >
 
@@ -263,7 +225,7 @@ Also, note the number of times the exit is called in this trace.  Each lookup ac
 
 <img style="float: right;" width="50%" vspace="5" alt="Lookup Exit Trace, Optimized" src=images/Module20-User-Exit_Routines/Module20_Slide24.jpeg title="Lookup Exit Trace, Optimized"/>
 
-This is the same view but a new trace.  In this trace the “Optimize” flag was turned on.  This means that the logic table only has one executed LUEX function for the entire first event file record.  Because the LKC value of “D” did not change between calls to the exit, the exit is not called again.  
+This is the same view but a new trace.  In this trace the “Optimize” flag was turned on. This means that the logic table only has one executed LUEX function for the entire first source file record. Because the LKC value of “D” did not change between calls to the exit, the exit is not called again.  
 
 <div style="clear: right" >
 
@@ -279,28 +241,13 @@ The difference between the logic tables for optimized and non-optimized is very 
 
 <img style="float: right;" width="50%" vspace="5" alt="Static Parameters" src=images/Module20-User-Exit_Routines/Module20_Slide26.jpeg title="Static Parameters"/>
 
-The trace shows the values placed in the key by the LKDT, LKC and other look-up key functions, the value of “D” in our example view.  These parameters are passed to the look-up exit.  It also shows the static parameters passed as well.  These are shown on the end of the LKEX function row, after the Look-up Exit page.  Similar parameters can be seen in the trace for Read and Write exits if start-up parameters are passed.
+The trace shows the values placed in the key by the LKE, LKC and other lookup key functions, the value of “D” in our example view.  These parameters are passed to the lookup exit. It also shows the static parameters passed as well. These are shown on the end of the LUEX function row, after the Lookup Exit name.  Similar parameters can be seen in the trace for Read and Write exits if start-up parameters are passed.
 
 <div style="clear: right" >
 
 ## Exit Program Specification and Linkage
 
-<img style="float: right;" width="50%" vspace="5" alt="Exit Program Specification and Linkage" src=images/Module20-User-Exit_Routines/Module20_Slide27.jpeg title="Exit Program Specification and Linkage"/>
-
-Exits must be written following the GenevaERS User Exit guidelines.   These specify a standard set of linkage parameters to interact with GVBMR95 and GVBMR88.  They include: 
-- A standard set of pointers, used to access various data provided by GenevaERS, including the event record, the extract record, look-up keys, and a work area for maintaining working storage parameters for the exit.  
-
-- Environment data, including the Phase Code, Open, Read, or Close, informing the exit what the status of processing is.  Exits are called during the 
-    - Open phase, to prepare for processing, 
-    - Read phase as event file records are processed, and 
-    - Close phase, to print out control reports, flush final records, or clean up.
-
-- Return codes values, informing GenevaERS of the results of processing.  These can include:
-    - A Found, Not Found, or Skip Event Record condition on a Look-up Exit, 
-    - An End of File on for a Read exit, or 
-    - Write the standard extract record, Write a different record and then return to the exit for processing, or Skip the extract record and continue processing for Write Exits
-
-All Exits may signal view or process level errors as well.
+Exits must be written following the GenevaERS User Exit guidelines. These specify a standard set of linkage parameters to interact with GVBMR95 and GVBMR88.
 
 More details about how to create a user exit can be found in the [User Exit Programming Guide](UserExitGuide.md)
 
@@ -308,20 +255,7 @@ More details about how to create a user exit can be found in the [User Exit Prog
 
 ## GenevaERS Standard Sort Exit
 
-<img style="float: right;" width="50%" vspace="5" alt="GenevaERS Standard Sort Exit" src=images/Module20-User-Exit_Routines/Module20_Slide28.jpeg title="GenevaERS Standard Sort Exit"/>
-
-As noted earlier this graphic shows the potential for a Sort Utility Input or Read Exit.  GenevaERS uses standard sort utilities provided with the operating system or otherwise.  These utilities typically allow for a read exit to the sort utility, a program which stands between the sort utility and the file to be sorted.  Procedures for writing these exits depend upon the sort utility used.  Refer to the sort utility documentation for instructions.
-
-As an example of this type of exit, GenevaERS provides a page GVBSR02.  This page accepts a parameter file, instructing it which view(s) to create multiple permutations for.  Before the utility sorts the records, the Sort Exit will replicate the extracted data, creating new records with permuted sort keys.  For example, a record with a sort key of A, B and C will be duplicated, and a records for of the following would be created:
-B, C, A, 
-C, A, B, 
-C, B, A
-A, C, B
-B, A, C
-
-This produces many more possible outputs without creating all the different views or exploding the extract files with all the possible combination.  
-
-Using this exit requires concatenating special sort cards to the GVBMR95 generated sort cards, and creating parameters for the Logic Table programs instructing them to generate permuted VDP views, similar to the process it undertakes when it creates the JLT for the reference file phase. These views are never found in the Metadata Repository; they are temporary views only in that run’s VDP.  They are required in the VDP for GVBMR88 to refer to in processing the permuted records. 
+As noted earlier there is potential for a Sort Utility Input or Read Exit.  GenevaERS uses standard sort utilities provided with the operating system or otherwise.  These utilities typically allow for a read exit to the sort utility, a program which stands between the sort utility and the file to be sorted.  Procedures for writing these exits depend upon the sort utility used.  Refer to the sort utility documentation for instructions.
 
 # Function Overview
 
@@ -330,7 +264,6 @@ Using this exit requires concatenating special sort cards to the GVBMR95 generat
 This page has introduced the following Logic Table Function Code:
 - REEX - Read a new Event Record with a user exit
 - LUEX - Lookup calling a user exit
-- WREX - Write calling a user exit
 
 [Click here to access the list of the most common Logic Table Functions for reference.](Intro11a_Logic_Table_Function_Codes.md)
 

--- a/docs/UserExitGuide.md
+++ b/docs/UserExitGuide.md
@@ -5,73 +5,74 @@ nav_order: 1
 
 # User Exit Overview
 
-The [Introduction to User Exit Routines](Intro20-User-Exit_Routines.md) gives an overview of User Exits.  
+Exits are a common tool that allow a software product to call custom coded programs at specific points to perform functions the product itself does not do.
+GenevaERS has four points which can invoke a user exit.  The first three are Extract Phase exits, and the last one a Format Phase exit.
+  - __Read Exits__ present source data to GenevaERS threads for processing.  It is associated with an Extract-Phase Source Logical Record. It is called each time the source records in the input buffer have been processed, until EOF is indicated. IT is associated with the REEX logic table function.
+  - __Lookup Exits__ return records in response to Lookup parameters, such as a key.  These exits can be used as simple function calls. It is associated with a lookup LR and a LUEX logic table function (rather than a LUSM which searches the in memory lookup data), and is called each time a lookup to that LR is required.  
+  - __Write Exits__ accept extract records and can manipulate them before being written to extract files. It is associated with a View or a write statement within a view and creates the extract record, or can indicate to skip a record.
+  - __Format Exits__, the only GVBMR88 exit which accept summarized and formatted Format Phase output records prior to being written to files. It is associated with a View that is assigned to the Format Phase.  Format exits are very similar to write exits, except that the record being dealt with is the final output record, rather than the extract record. Because of its infrequent use, we won’t describe this exit in any more detail here.
 
-Exits are a common concept that allows software products to call custom coded programs at specific points to perform functions the tool itself does not do.
-GenevaERS has four major points which can invoke a user exit.  The first three are Extract Phase exits, and are used much more frequently than the Format Phase exit.  They are:
-  - __Read Exits__, which present event file records to GenevaERS threads for processing.  It is associated with an event LR and the RENX logic table function, and is called each time the event LR records in the input buffer have been processed.
-  - __Lookup Exits__, which accept join parameters and return looked up records in response to individual joins.  These exits can also be used as simple function calls.  It is associated with a lookup LR and a LUEX logic table function (rather than a LUSM which searches the in memory lookup data), and is called each time a join to that LR is required.  
-  - __Write Exits__, which accept extract records and can manipulate them before being written to extract files.  It is associated with a view or a write statement within a view and the WREX logic table function (rather than WRIN, WRDT, or WRSU functions) and creates the extract record  
-  - __Format Exits__, the only GVBMR88 exit which accept summarized and formatted Format Phase output records prior to being written to files.  It is associated with a view that is assigned to the Format Phase.  Format exits are very similar to write exits, except that the record being dealt with is the final output record, rather than the extract record.  Because of its infrequent use, we won’t describe this exit in any more detail here.
+The [Introduction to User Exit Routines](Intro20-User-Exit_Routines.md) gives an overview of User Exits and how to define them in the GenevaERS Workbench.  
 
 # Sample User Exits and Relative Exit Complexities
 
 The following gives a better sense of each exit type, and the complexity and options involved for each one. 
 
 ## Read Exit
-In the early days of GenevaERS a sample read exit read the GenevaERS Field Definition file and calculated the start position of each field based upon the lengths of the prior fields in the file, a field not stored on the file.  GenevaERS at the time did not read VSAM files, the format of the Field Definition File, so the Read exit performed this function. THe exit detected a change in the logical record for the fields, and start the running position over at 0.  This allowed GenevaERS to produce reports of its own metadata.
 
-Besides the file format, it was written because this isn’t a function well suited to GenevaERS.  GenevaERS doesn’t do many functions that carry values from one record to the next.  And it doesn’t do any "look ahead" functions, like when the next record in the file determines if the current record should be written.  GenevaERS is built for business event processing, not “set processes” evaluating a set of records.
+The read exit emulates an access method; in other words instead of GenevaERS calling the system BSAM access method to get data from disk, it calls the program name specified. This means that the program must return the results that an access method would return. GenevaERS can handle data records returned in blocks with RECFM, LRECL and BLKSIZ set accordingly. This is an efficient way of passing data to GenevaERS, so the exit does not need to be called for every new record, only for every new block.
 
-To use this exit one must create a logical record which matched the output from the read exit.  That output was the 20 fields or so on Field Definition File, plus the new field.  GenevaERS knows nothing about the input to the read exit.  For all GenevaERS knew, the exit could have read 10 different files and combined them all together to make an event file.  It could have added 19 of the fields on to the field before passing it on to GenevaERS.  
-
-The read exit emulates an access method; in other words instead of GenevaERS calling the system BSAM access method to get data from disk, it calls the program name specified.  This means that the program must return the results that an access method would return.   Access methods that read from disks don’t know about the actual length of the data records processed by the program.  Rather their record lengths are blocks.  
-
-This read exit read (using a the standard VSAM access method) and manipulated one Field Definition record at a time.  It could have been created as if the block size was the length of one of my field definition records, perhaps 50 bytes in length.  The block size would equal the Logical Record Length (LRECL).  However, this meant that GenevaERS would be calling the exit each time a new record was needed.  The overhead for calling a subprogram is very high.  GenevaERS has to save its register values before calling, and then they have to be restored before going back.  This CPU time can really add up on a large file.  
-
-Thus a more efficient method is for the read exit to process many Field Definition records as if they had come from disk as one block, and then returning the full block to GenevaERS.  GenevaERS will parse the individual records according to the Logical Record Length, and only return to the read exit when a new block of data is needed.   
-
-This process can make a read exit quite complex to create.
+The most efficient method is for the read exit to process many records as if they had come from disk as one block, and then return the full block to GenevaERS.  GenevaERS will parse the individual records according to the Logical Record Length, and only return to the read exit when a new block of data is needed.
 
 ## Lookup Exits 
 
-Look-up exits are probably the easiest to create.  This is because they accept a set of parameters and return a record.  The parameters passed to the lookup exit are whatever values are placed in the fields of the join key.  These can be constants, fields from the event file, or fields from another lookup, including calls to other exits.  The output from the lookup exit is a record that must match the LR for the “reference file” record it is to return.   
+Lookup exits accept a set of parameters and return a record.  The parameters passed to the lookup exit are whatever values are placed in the fields of the Lookup key. These can be constants, fields from the source file, or fields from another lookup, including calls to other exits. The output from the lookup exit is a record that must match the LR for the “reference file” record it is to return.
 
 Although it appears to a GenevaERS developer as if GenevaERS has taken the keys and performed a search of a reference table to find the appropriate record, the exit may have done no such thing.  In fact, it could do something as simple as reordering the fields passed to it and returning the record.
 
-An early sample lookup exit kept a copy of the key it had been passed in the last call, and compared the key from the current call with that key.  If the keys were the same, then it returned a “not found” condition.  If they were different, it returned a “found” condition.  This exit was called by multiple views, which had selection logic to only include found records. This allowed selection of an event record only once no matter how many views it qualified for.  
+One example of a lookup exit kept a copy of the key it had been passed in the last call, and compared the key from the current call with that key. If the keys were the same, then it returned a “not found” condition.  If they were different, it returned a “found” condition.  This exit was called by multiple views, which had selection logic to only include found records. This allowed selection of a source record only once no matter how many views it qualified for.  
 
-Lookup exits have been written to perform math calculations that GenevaERS didn’t do natively.  In fact, before GenevaERS had extract time calculations, a generalized user exit allowed passing two numbers and an operator.  The resulting record contained the results of the math.  Many GenevaERS functions have first appeared as user exits, and were later folded into the main code base.
+Lookup exits can be written to perform complex mathematical calculations that GenevaERS doesn’t do natively. The resulting record contains the result of the calculation.
 
 ## Write Exits
 
-Extract exits are called whenever a view is to write an extract record.  The write exit is passed the extract record, and the event record.  It can evaluate these records and determine if it was to: 
-  -	Tell GenevaERS to write a record the exit specifies (could be any record) and continue with event file processing.
+Extract exits are called whenever a view is to write an extract record. The write exit is passed the extract record, and the source record. It can evaluate these records and determine if it is to: 
+  -	Tell GenevaERS to write a record the exit specifies (could be any record) and continue with source file processing.
   -	Tell GenevaERS to skip this extract record and go on
   -	Tell GenevaERS to write a record the exit specifies (could be any record) and return to the exit to do more processing.
 
-The exit can manipulate the exit record; substitute a new record, table the extract record in some way and then dump the table at the end of event file processing, among others.  Note, though, that unlike read exits which open and actually read files, write exits typically do not.  They return records to GenevaERS to write to the extract file.  They could do their own IO, but there is typically no benefit to doing so.  GenevaERS’s write routines are very efficient.  
+The exit can manipulate the exit record; substitute a new record, table the extract record in some way and then dump the table at the end of source file processing, among others.  Note, though, that unlike read exits which open and actually read files, write exits typically do not.  They return records to GenevaERS to write to the extract file.  They could do their own IO, but there is typically no benefit to doing so. GenevaERS’s write routines are very efficient.  
 
-Write exits are in between read and lookup exits for complexity.  This is mainly because of the complexity of dealing with extract records.  The exit must know what the extract record will look like for a particular view.  This might be easiest to determine by actually writing the view, and inspecting the extracted records to find positions and lengths.  Any changes in the views can create a new to update the write exit.  Write exits outputs typically have nothing to do with LRs.  
+The write exit must know what the extract record will look like for a particular View. This might be easiest to determine by writing the View, then generating the LR for the extract record. Any changes in the Views can create a new to update the write exit.
 
-[Extract Time Summarization](Intro18-ETS_and_Other_Functions.md) made its first appearance as a write exit.  The exit was called on each extract record.  The exit allocated its own memory space, and built a stack of summarized event records.  Only if the extract record caused the exit to overflow the stack did the exit tell GenevaERS to write a record.  When the thread has finished processing, on the last call to the write exit, the write exit would loop through the stack and instruct GenevaERS to write each record in the stack and return to it for additional processing until the internal table was empty.
+Write exits are defined in the WRITE statement.
 
 ## Calling and Parameter Overview
 
-Each exit receives a set of static parameters that do not change throughout event file processing.  These can be used to further generalize an exit.
+Each exit receives a set of static parameters that do not change throughout source file processing.  These can be used to further generalize an exit.
 
-For example, the small lookup exit described above accepted a set of static parameters that described how long the passed key was from the join.  It would use this length to determine what length of data to store and compare.  In this way, this same exit could be used on multiple joins with different keys, from 5 bytes to 50 bytes, regardless of whether the key was composed of 1 field or 50.  This same approach was used by the calculation exit so that it could work with different sizes of numbers being passed to it, and different arithmetic functions. 
+For example, a lookup exit will accept a set of parameters that described how long the lookup key is. It can use this length to determine what length of data to store and compare. In this way, this same exit could be used on multiple lookups with different keys, of different lengths, regardless of whether the key was composed of 1 field or 50. This same approach can be used by a calculation exit so that it can work with different sizes of numbers, and different arithmetic functions.
 
-Each exit is called:
- - Once before event file processing begins so it can initialize memory and set up shop. 
- - Multiple times during processing, depending on the exit type (per block of data required for read exits, for each lookup, or for each extract record to be written) 
- - One time after event file processing is complete to perform clean up.  The purpose of these calls are indicated to the exit through a phase code.
+The Each exit is called:
+ - Once before each source file is processed, typically in a new subtask, so it can initialize memory. This is the OPEN phase.
+ - Multiple times during processing, depending on the exit type (per block of data required for read exits, for each lookup, or for each extract record to be written). This is called the READ phase, even for lookup and write exits.
+ - One time after each source file is processed to perform clean up. This is the CLOSE phase.
+ 
+Assembler write exits are also called:
+ - Once before any subtasks are attached. This is the INIT phase.
+ - Once after all subtasks are complete. This is the TERM phase.
+ 
+ This is specifically designed so that the write exit can open files from the parent task, and close those files when all subtasks (source file reads) are complete.
 
 # Calling Parameters
 
-The GenevaERS Performance Engine Extract Engine (GVBMR95) uses a standard call parameter list when invoking user exits.  This structure is passed to user exits by MR95 (and other custom GenevaERS processes like XRCK the common key buffering process) to pass data (where applicable) and return codes back to MR95 via this structure.  
+The GenevaERS Performance Engine Extract Engine (GVBMR95) uses a standard call parameter list when invoking user exits. This structure is passed to user exits by GVBMR95 to pass and receive data (where applicable) and return codes.  
 
 Below are the COBOL and Assembler versions of the Structures (copybooks) with explanations of the individual fields above the corresponding field.  
+
+The [COBOL copybook for GenevaERS exit parameter list](this should be a link to the actual source) 
+
+Note: The terms 'Event data' and 'Event file' were previously used to refer to the Source data and Source file. The term 'join' was previously used for the term 'lookup'.
 
 ##  Environment Data
 
@@ -98,7 +99,7 @@ The Value of X95PARM1-ENV-DATA Is Passed From GVBMR95.
 
 Specifics of each field are below.  
 
-The Thread Number is the number of the thread (the event file number) being processed.
+The Thread Number is the number of the thread (the source file number) being processed.
 
       05  X95PARM1-THREAD-NBR         PIC S9(04)  COMP.
 
@@ -109,42 +110,47 @@ The Phase Code defines what type of call to the exit is being executed in this i
           88  X95PARM1-READ-PHASE     VALUE 'RD'.
           88  X95PARM1-CLOSE-PHASE    VALUE 'CL'.
 
-- Open is a call to the exit the first time, before event file record processing begins
-- Read is on each call to the exit during event file record processing
-- Close is after event file record processing has finished.
+- Open is a call to the exit the first time, before source file record processing begins
+- Read is on each call to the exit during source file record processing
+- Close is after source file record processing has finished.
 
 The View ID is the view calling the exit.  This parameter is not applicable for Read Exits
 
       05  X95PARM1-CURRENT-VIEW-ID    PIC S9(09)  COMP.
 
-The following need greater definition here in this document. 
+The Environment Variable Table pointer is the address of the environment variable list. Environment variables can be set in DD EXTRENVV. Table entries are described by ENVVTBL in [GVBMR95C](https://github.com/genevaers/pe/blob/main/PM4/MAC/GVBMR95C.MAC)
 
       05  X95PARM1-ENV-VAR-TABLE-PTR  POINTER.
+
+These parameters are only applicable for Lookup Exits. X95PARM1-JOIN-STACK-PTR points to a slot in a stack where the address of the last found lookup from this exit is saved. The slots are managed by GVBMR95, but can be referenced by User exits. Each slot format is 12 bytes; 4 byte LR ID and 8 byte address of 'last found'.
+
       05  X95PARM1-JOIN-STEP-COUNT    PIC S9(09)  COMP.
       05  X95PARM1-JOIN-STACK-PTR     POINTER.
 
-The Process Date and Time is the start-up time of the Extract Phase process.
+The Process Date and Time is the data and time stamp from the XLT records.
 
       05  X95PARM1-PROCESS-DATE-TIME.
           10  X95PARM1-PROCESS-DATE   PIC  X(08).
           10  X95PARM1-PROCESS-TIME   PIC  X(08).
 
-The Error Reason code gives some description of why the process was aborted. 
+The following fields can be set by the User Exit.
+
+If the Error Reason code is set to be non-zero, then the text in the Error Buffer will be written to EXTRLOG and WTO.
 
       05  X95PARM1-ERROR-REASON       PIC S9(08)  COMP.
 
-The Error Buffer pointer and length fields allow for indicative data that caused the error to be printed in GVBMR95 control and run-time messages.  
+The Error Buffer pointer and length fields allow for indicative data that caused the error to be printed to EXTRLOG and WTO. The maximum length of the buffer is 126 bytes.
 
       05  X95PARM1-ERROR-BUFFER-PTR   POINTER.
       05  X95PARM1-ERROR-BUFFER-LEN   PIC S9(08)  COMP.
 
 ### X95PARM2-EVENT-FILE-DATA.
 
-The Event File structure gives the view data relative to the event file being processed by this thread.
+The Event File structure gives the view data relative to the source file being processed by this thread. Read exits may set these fields. If there is no read exit GVBMR95 sets these values.
 
     01  X95PARM2-EVENT-FILE-DATA.
         05  X95PARM2-EVENT-DDNAME       PIC  X(08).
-        05  X95PARM2-EVENT-REC-NBR      PIC S9(11)  COMP-3.
+        05  X95PARM2-EVENT-REC-NBR      PIC  9(16)  COMP.
         05  X95PARM2-EVENT-REC-FMT      PIC  X(01).
             88  X95PARM2-FIXED-LENGTH       VALUE 'F'.
             88  X95PARM2-VARIABLE-LENGTH    VALUE 'V'.
@@ -156,34 +162,34 @@ The Event File structure gives the view data relative to the event file being pr
 
 Specifics of each field are below.  
 
-The Value Of X95PARM2-EVENT-DDNAME Is Passed From GVBMR95.  This is the Event File DD Name of the thread being processed.
+The Value Of X95PARM2-EVENT-DDNAME Is Passed From GVBMR95.  This is the source File DD Name of the thread being processed.
 
      05  X95PARM2-EVENT-DDNAME       PIC  X(08).
 
-The Value Of X95PARM2-EVENT-REC-NBR Is Passed From GVBMR95.  This is the event file record number that is currently being processed.
+The value of X95PARM2-EVENT-REC-NBR is passed from GVBMR95.  This is the source file record number that is currently being processed. It is an 8 byte binary count.
 
-     05  X95PARM2-EVENT-REC-NBR      PIC S9(11)  COMP-3.
+     05  X95PARM2-EVENT-REC-NBR      PIC  9(16)  COMP.
 
-Read Exits set the value of X95PARM2-EVENT-REC-FMT in the Open Phase and pass it to GVBMR95.  GVBMR95 passes the value to Lookup Exits And Write Exits, representing the format of the event file being processed by this thread, for this and the following parameters.
+Read Exits may set the value of X95PARM2-EVENT-REC-FMT in the Open Phase and pass it to GVBMR95. GVBMR95 passes the value to Lookup Exits And Write Exits, representing the format of the source file being processed by this thread, for this and the following parameters.
 
      05  X95PARM2-EVENT-REC-FMT      PIC  X(01).
          88  X95PARM2-FIXED-LENGTH       VALUE 'F'.
          88  X95PARM2-VARIABLE-LENGTH    VALUE 'V'.
          88  X95PARM2-DELIMITED          VALUE 'D'.
 
-Read Exits set the value of X95PARM2-REC-FLD-DELIM in the Open Phase and pass it to GVBMR95.  GVBMR95 passes the value to Lookup Exits and Write Exits.
+Read Exits may set the value of X95PARM2-REC-FLD-DELIM in the Open Phase and pass it to GVBMR95. GVBMR95 passes the value to Lookup Exits and Write Exits.
 
      05  X95PARM2-REC-FLD-DELIM      PIC  X(01).
 
-Read Exits set the value of X95PARM2-Event-Rec-Len on every execution and pass it to GVBMR95.  GVBMR95 passes the value to Lookup Exits and Write Exits.
+Read Exits may set the value of X95PARM2-EVENT-REC-LEN on every execution and pass it to GVBMR95. GVBMR95 passes the value to Lookup Exits and Write Exits.
 
      05  X95PARM2-EVENT-REC-LEN      PIC S9(09)  COMP.
 
-Read Exits set the value of X95PARM2-Max-Rec-Len in the Open Phase and pass it to GVBMR95.  GVBMR95 passes the value to Lookup Exits and Write Exits.
+Read Exits may set the value of X95PARM2-MAX-REC-LEN in the Open Phase and pass it to GVBMR95. GVBMR95 passes the value to Lookup Exits and Write Exits.
 
      05  X95PARM2-MAX-REC-LEN        PIC S9(09)  COMP.
 
-Read Exits set the value of X95PARM2-Max-Block-Size in the Open Phase and pass it to GVBMR95.  GVBMR95 passes the value to Lookup Exits and Write Exits.
+Read Exits may set the value of X95PARM2-MAX-BLOCK-SIZE in the Open Phase and pass it to GVBMR95. GVBMR95 passes the value to Lookup Exits and Write Exits.
 
      05  X95PARM2-MAX-BLOCK-SIZE     PIC S9(09)  COMP.
 
@@ -191,7 +197,7 @@ Read Exits set the value of X95PARM2-Max-Block-Size in the Open Phase and pass i
 
 ### X95PARM3-STARTUP-DATA
 
-The layout of X95PARM3-Startup-Data is defined by the GenevaERS configuration for the specific processes involved.  So the structure of the record layout is dependent upon the record layouts (LRs) the GenevaERS configuration.  The startup data values are constant throughout event file record processing.
+Startup data values can be set for Read, Lookup and Write exits. There is no fixed layout of X95PARM3-Startup-Data. The maximum length allowed is 32 bytes.
 
 These parameters can be used to generalize an exit to be used for more GenevaERS processes, for example telling the exit to perform a set of functions when called in this context throughout this GenevaERS processing.  For example, a single lookup exit might do multiple mathematical functions, and the function to be performed each time it is called for a specific lookup logical record could be specified as a start-up parameter. 
 
@@ -205,31 +211,38 @@ These values are passed to the Exit Program from GVBMR95.
 
     01  X95PARM3-STARTUP-DATA           PIC  X(32).
 
-When the exit is first called (the Open Phase call) the exit needs to point the record layout inside your program (in the example below the Ls-Startup-Parms)to the location of value passed as X95PARM3-Startup-Data by executing the statement:
+When the exit is first called (the Open Phase call) the exit needs to point the record layout inside your program (in the example below the Ls-Startup-Parms) to the location of value passed as X95PARM3-Startup-Data by executing the statement:
 
 `Set Address Of Ls-Startup-Parms To Address Of X95PARM3-Startup-Data`
 
-## Event, Extract and Lookup Record Parameters
+## Source, Extract and Lookup Record Parameters
 
-### X95PARM4-EVENT-REC
+### X95PARM4-EVENT-REC-PTR
 
-X95PARM4-Event-Rec is not applicable to Read Exits. For Lookup and Write Exits, this parameter points to the current record from the Event File.
+X95PARM4-EVENT-REC-PTR is not applicable to Read Exits. For Lookup and Write Exits, this parameter points to the current record from the Source File.
 
-Like the Start-up data, the structure of the event file record is dependent upon the specific GenevaERS processing being performed. 
+Like the Startup data, the structure of the Source file record is dependent upon the specific GenevaERS processing being performed. 
 
-    01  X95PARM4-EVENT-REC              PIC  X(01).
+    01  X95PARM4-EVENT-REC-PTR.
+           05  X95PARM4-EVENT-REC-PTR-HIGH     POINTER.
+           05  X95PARM4-EVENT-REC-PTR-LOW      POINTER.
 
-To point your exits definition of the event file record (for this example, Ls-Event-Rec) to the address of the data contained i X95PARM4-Event-Rec execute the statement:
+X95PARM4-EVENT-REC-PTR points to an 8 byte 64-bit address. 
+Currently GenevaERS only supports COBOL exits compiled for 31-bit addressing, but some of the parameters contain 64-bit addresses. COBOL exits must use the low 4-bytes of the address only.
 
-`Set Address Of Ls-Event-Rec To Address Of X95PARM4-Event-Rec`
+<!-- more notes here on this topic? -->
 
-Do this whenever this program is given control as the location of the event file record changes on each call to the exit.
+To point your exit's definition of the source file record (for this example, LS-EVENT-REC) to the address of the data contained in X95PARM4-EVENT-REC execute the statement:
+
+`Set Address Of LS-EVENT-REC To X95PARM4-EVENT-REC-PTR-LOW`
+
+Do this whenever this program is given control as the location of the source file record changes on each call to the exit.
 
 ### X95PARM5-EXTRACT-REC
 
-Like the Event File Record structure, X95PARM5-Extract-Rec is not applicable to Read Exits. For Lookup and Write Exits, this parameter points to the current Extract Record.  
+Like the Source File Record structure, X95PARM5-Extract-Rec is not applicable to Read Exits. For Lookup and Write Exits, this parameter points to the current Extract Record.  
 
-The layout of the beginning of each extract record is fixed as outlined in [Introduction to Format Phase Views](Intro17_Format_Phase_Views.md), but the layout of the rest of the record is determined by the view.  The following is the structure of the fixed portion of the record:
+The layout of the beginning of each extract record is fixed as outlined in [Introduction to Format Phase Views](Intro17_Format_Phase_Views.md), but the layout of the rest of the record is determined by the View. The following is the structure of the fixed portion of the record:
 
     01  X95PARM5-EXTRACT-REC.
         05  X95PARM5-EXTRACT-RDW.
@@ -243,14 +256,13 @@ The layout of the beginning of each extract record is fixed as outlined in [Intr
             10  X95PARM5-VIEW-ID            PIC S9(09)  COMP.
         05  X95PARM5-EXTRACT-VAR-LEN-AREA   PIC  X(01).
 
-To point your exits copybook structure (for this example, Ls-Extract-Data) to the address of the data contained in X95PARM5-Var-Len-Area execute the statement whenever this program is given control:
+To point your exit's copybook structure (for this example, Ls-Extract-Data) to the address of the data contained in X95PARM5-Var-Len-Area execute the statement whenever this program is given control:
 
 `Set Address Of Ls-Extract-Rec To Address Of X95PARM5-Extract-Var-Len-Area`
 
-
 ### X95PARM6-LOOKUP-KEY
 
-Like the prior parameters, the layout of X95PARM6-Lookup-Key is dependent upon the GenevaERS processes being run, and the metadata defining them.  For Read and Write Exits this parameter is not applicable. 
+This parameter is only applicable to Lookup exits. Like the prior parameters, the layout of X95PARM6-Lookup-Key is dependent upon the GenevaERS processes being run, and the metadata defining them.
 
 For Lookup Exits the structure is set in the View Logic Text or in Join Step Parameters. The values are populated by the logic table LK rows. This value is passed to the exit program from GVBMR95.
 
@@ -263,21 +275,24 @@ To point your program's copybooks structure (in this example, Ls-Lookup-Parms) t
 ## Working Storage
 
 ### X95PARM7-WORK-AREA-ANCHOR
-GVBMR95 does not guarantee that working storage in a COBOL program will be remain in the same state on subsequent calls to the program, so any data items which need to be retained between calls should be placed in a dynamically allocated area, and the address of that area stored in this pointer, which will be returned by GVBMR95 on each subsequent call.
+GVBMR95 does not guarantee that working storage in a COBOL program will remain in the same state on subsequent calls to the program, so any data items which need to be retained between calls should be placed in a dynamically allocated area, and the address of that area stored in this pointer, which will be returned by GVBMR95 on each subsequent call.
 
  01  X95PARM7-WORK-AREA-ANCHOR       POINTER.
 
-During the open phase, the GenevaERS routine GVBUR05 should be called to allocate a work area (in this example, LS-Work-Area) and X95PARM7-WORK-AREA-ANCHOR should be set to point to it.  For example:
+During the open phase, the GenevaERS routine GVBUR05 should be called to allocate a work area (in this example, LS-Work-Area) and X95PARM7-WORK-AREA-ANCHOR should be set to point to it.  
 
-`Move Length Of Ls-Work-Area To Ws-Work-Area-Length`
+For example:
 
-`Call GVBUR05 Using X95PARM7-Work-Area-Anchor Ws-Work-Area-Length`
-
-`Set Address Of Ls-Work-Area To X95PARM7-Work-Area-Anchor`
+          MOVE LENGTH OF LS-WORK-AREA TO WS-WORK-AREA-LENGTH
+          CALL GVBUR05
+              USING X95PARM7-WORK-AREA-ANCHOR
+                    WS-WORK-AREA-LENGTH
+          SET ADDRESS OF LS-WORK-AREA TO
+              X95PARM7-WORK-AREA-ANCHOR
 
 On Subsequent Calls, X95PARM7-WORK-AREA-ANCHOR retains its value and may be pointed to the structure again, by using:
 
-`Set Address Of Ls-Work-Area To X95PARM7-Work-Area-Anchor`
+          SET ADDRESS OF LS-WORK-AREA TO X95PARM7-WORK-AREA-ANCHOR
 
 ## Return Code and Result Set
 
@@ -302,201 +317,67 @@ X95PARM8-Return-Code should be set in the exit program to the numeric code to be
           88  X95PARM8-ABORT-RUN              VALUE +16.
 
 __Lookup Exits__:
-- _Lookup Found+_:  A return value of +0 signals GVBMR95 that the lookup exit successfully returned a result that can be used by the view.
+- _Lookup Found+_:  A return value of +0 signals to GVBMR95 that the lookup exit successfully returned a result pointed to by X95PARM9-RESULT-PTR.
 - _Lookup Not Found_:  Alternatively a return code value of +4 signals GVBMR95 that no successful result was returned, so the view should use the Not Found condition.
-- _Lookup Skip Event File Record_: A +8 signals GVBMR95 that the view should completely bypass further processing of the event file record.  This means execution continues with the next view, so no extract record will be written for the view for this record, but the view is not disabled from processing future records (see Disabled below).
+- _Lookup Skip Event File Record_: A +8 signals GVBMR95 that the view should completely bypass further processing of the event file record.  This means execution continues with the next record, so no extract record will be written for the view for this record, but the view is not disabled from processing future records (see Disabled below).
 
 __Write Exits__:
-- _Write Extract Record_:  A return value of +0 signals GVBMR95 to write the record returned by the Write Exit to the extract file.
-- _Write and Repeat Call_: A return code of +4 signals GVBMR95 to write the record returned by the Write Exit, and then return to the Write Exit for further processing.  This return code was used by the initial Extract Time Summarization write exit to dump all tabled records to the extract file at the conclusion of processing in the Close Phase with the last call being a +0 return code.
+- _Write Extract Record_:  A return value of +0 signals GVBMR95 to write the record returned by the Write Exit pointed to by X95PARM9-RESULT-PTR, to the extract file.
+- _Write and Repeat Call_: A return code of +4 signals GVBMR95 to write the record returned by the Write Exit, and then return to the Write Exit for further processing.
 - _Skip Extract Record_:  A return code of +8 signals GVBMR95 that no extract record should be written after this call, and processing should continue to the next logic table function.
 
 __Read Exits__: 
-- _Process Buffer_:  A return code of +0 signals GVBMR95 to process the buffer returned by the Read Exit through the views.  
-- _End of File_:  A return code of +8 signals GVBMR95 that end of file has been reached by the read exit; GVBMR95 should move to the Close Phase.
-
+- _Process Buffer_:  A return code of +0 signals GVBMR95 to process the buffer returned by the Read Exit.
+- _End of File_:  A return code of +8 signals GVBMR95 that end of file has been reached by the read exit; The current GVBMR95 subtask should move to the Close Phase.
 
 __Error Processing__
-- _Disable Current View_:  Only applicable for Lookup and Write Exits, (Not Read Exits, which are not view specific) a return code of +12 signals GVBMR95 to disable the view for further processing.  Although extract records have been written to the output file, no further records will be written.  The control report will signal a view was disabled.  If the view is a Format Phase View, the extract records will be skipped and no output will be produced.  GenevaERS cannot stop automatically downstream non-extract file processing, but GenevaERS facilities can be used to build processes to detect disabled views.
+- _Disable Current View_:  Only applicable for Lookup and Write Exits, (Not Read Exits, which are not view specific) a return code of +12 signals GVBMR95 to disable the view for further processing. The control report will signal a view was disabled.
+
+     If the view is a Format Phase View, the extract records will be skipped and no output will be produced.  GenevaERS cannot stop automatically downstream non-extract file processing, but GenevaERS facilities can be used to build processes to detect disabled views.
 - _Abort Processing_:  A return code of +16 signals GVBMR95 to immediately stop all processing.
 
-The X95PARM1-ERROR-REASON (in the PARM1 structure) can be populated for either the disable view or abort run return values.  This value will be printed in the z/OS Message Logs, along with the indicative data pointed to by the error buffer pointer.
+The X95PARM1-ERROR-REASON (in the PARM1 structure) can be populated for any return values. This value will be printed in the z/OS Message Logs, along with the indicative data pointed to by the error buffer pointer.
 
 ### X95PARM9-RESULT-PTR and X95PARMA-RESULT-BLOCK-SIZE
 
-Like Exit Working Storage, memory for the result sets are not provided by GVBMR95. Exits are responsible for allocations of this memory. X95PARM9-RESULT-PTR should be set in the exit program to the address of the structure to be returned to GVBMR95. 
+Memory for the result sets are not provided by GVBMR95. Exits are responsible for allocations of this memory. X95PARM9-RESULT-PTR should be set in the exit program to the address of the structure to be returned to GVBMR95.
 
-     01  X95PARM9-RESULT-PTR             POINTER.
+X95PARM9-RESULT-PTR points to an 8 byte 64-bit address. Currently GenevaERS only supports COBOL exits compiled for 31-bit addressing, but some of GenevaERS's parameters contain 64-bit addresses. COBOL exits must use the low 4-bytes of the address only. Hence for the COBOL version of the parameter list we define a 'high' and 'low' field.
 
-The values and structures returned in this area must match the LRs defined for them, for either Look-up or Read Exits. 
+<!-- more notes here on this topic? -->
 
-Because Write Exit create only extract record typically written directly to extract files and not subject to further view processing, they may not have this requirement.  If the view results are piped to another set of views, they may also need to match the describing LRs.  
+       01  X95PARM9-RESULT-PTR.
+           05  X95PARM9-RESULT-PTR-HIGH        POINTER.
+           05  X95PARM9-RESULT-PTR-NUMERICH    REDEFINES
+               X95PARM9-RESULT-PTR-HIGH        PIC S9(09)  COMP.
+           05  X95PARM9-RESULT-PTR-LOW         POINTER.
+           05  X95PARM9-RESULT-PTR-NUMERICL    REDEFINES
+               X95PARM9-RESULT-PTR-LOW         PIC S9(09)  COMP.
 
-To point X95PARM9-Result-Ptr to your own structure (in this example, Ws-Result), execute the statement whenever this program is given control:
 
-`Set X95PARM9-Result-Ptr To Address Of Ws-Result`
+To point X95PARM9-RESULT-PTR to your own structure (in this example, WS-RESULT), execute the statement whenever this program is given control:
 
-_Lookup Exits Only_:  Though Optional, it is a good exit programming practice to move -1 to X95PARM9-Result-Ptr-Numeric when the lookup result is "Not Found".  This guarantees that the pointer is no longer pointing to valid data.
+      SET  X95PARM9-RESULT-PTR-LOW TO ADDRESS OF WS-RESULT                        
+      MOVE ZERO TO X95PARM9-RESULT-PTR-NUMERIC
+
+_Lookup Exits Only_:  Though Optional, it is a good exit programming practice to move -1 to X95PARM9-RESULT-PTR-NUMERICH and X95PARM9-RESULT-PTR-NUMERICL when the lookup result is "Not Found". This guarantees that the pointer is no longer pointing to valid data.
 
     01  X95PARM9-RESULT-PTR-NUMERIC     REDEFINES
         X95PARM9-RESULT-PTR             PIC S9(09)  COMP.
 
-_Read Exits Only_: During the Open Phase, Read Exits should return the first event record block. 
+_Read Exits Only_: During the Open Phase, Read Exits should return the first event record block.
 
-Read Exits should set the value of X95PARMa-Result-Block-Size to the length of the block pointed to by X95PARM9-Result-Ptr.
+Read Exits should set the value of X95PARMA-RESULT-BLOCK-SIZE to the length of the block pointed to by X95PARM9-RESULT-PTR.
 
     01  X95PARMA-RESULT-BLOCK-SIZE      PIC S9(09)  COMP.
 
-END X95PARMA-RESULT-BLOCK-SIZE
 
 # ASSEMBLER VERSION GVBX95PA
 
-The following are the structures if z/OS Assembler is used for the exit.
-
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *                                                                     *
-    *        GenevaERS Provided Parameter List 
-    *                                                                     *
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *
-    GENPARM  DSECT                  GenevaERS  PARAMETER LIST
-    *
-    GPENVA   DS    AL04             ENVIRONMENT  INFO ADDR
-    GPFILEA  DS    AL04             FILE         INFO ADDR
-    GPSTARTA DS    AL04             STARTUP      DATA ADDR
-    GPEVENTA DS    AL04             EVENT      RECORD ADDR      (N/A)
-    GPEXTRA  DS    AL04             EXTRACT    RECORD ADDR      (N/A)
-    GPKEYA   DS    AL04             LOOK-UP    KEY    ADDR      (N/A)
-    GPWORKA  DS    AL04             WORK AREA POINTER ADDR
-    *
-    GPRTNCA  DS    AL04             RETURN CODE       ADDR
-    GPBLOCKA DS    AL04             OUTPUT BLOCK PTR  ADDR
-    GPBLKSIZ DS    AL04             OUTPUT BLOCK SIZE ADDR
-            SPACE 3
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *        Environment Information
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *
-    GENENV   DSECT                  ENVIRONMENT INFORMATION
-    *
-    GPTHRDNO DS    HL02             CURRENT THREAD   NUMBER
-    GPPHASE  DS    CL02             CURRENT EXECUTION PHASE
-    GPVIEW#  DS    FL04             CURRENT EXECUTING  VIEW
-    GPENVVA  DS    AL04             ENV VARIABLE TABLE ("MR95ENVV") ADDR
-    GPJSTPCT DS    FL04             JOIN STEP COUNT
-    GPJSTKA  DS    AL04             JOIN STACK ADDRESS
-    GP_PROCESS_DATE_TIME DS 0XL16   Process Date and time
-    GP_PROCESS_DATE      DS  XL8    Date
-    GP_PROCESS_TIME      DS  XL8    Time
-    GP_ERROR_REASON      DS  FL04   Error reason code
-    GP_ERROR_BUFFER_PTR  DS  AL04   -> error text
-    GP_ERROR_BUFFER_LEN  DS  FL04   To exit - set to length of buffer
-    *                               from exit - set to text length
-            Space 3
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *        File Information
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *
-    GENFILE  DSECT                  EVENT FILE   INFORMATION
-    *
-    GPDDNAME DS    CL08             EVENT  FILE  DDNAME
-    GPRECCNT DS    PL06             EVENT  FILE  RECORD COUNT
-    GPRECFMT DS    CL01             RECORD FORMAT  (F,V,D)
-    GPRECDEL DS    CL01             RECORD DELIMITER
-    GPRECLEN DS    FL04             RECORD LEN   CURRENT
-    GPRECMAX DS    FL04             RECORD LEN   MAXIMUM
-    GPBLKMAX DS    FL04             BLOCK  SIZE  MAXIMUM
-    *
-            Space 3
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *        Startup Data Information
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *
-    GENSTART DSECT
-    *
-    GP_STARTUP_DATA DS CL32
-    *
-            Space 3
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *        Event Record Information
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *
-    GENEVENT DSECT
-    *
-    GP_EVENT_REC    DS C
-    *
-            Space 3
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *        Extract Record Information
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *
-    GENEXTR  DSECT
-    *
-    GP_EXTRACT_REC          DS  0CL17
-    GP_EXTRACT_RDW          DS  0XL4
-    GP_EXT_REC_LENGTH       DS  XL2
-                            DS  XL2
-    GP_EXTRACT_PREFIX       DS  0CL12
-    GP_SORT_KEY_LENGTH      DS  XL2
-    GP_TITLE_KEY_LENGTH     DS  XL2
-    GP_DATA_AREA_LENGTH     DS  XL2
-    GP_NBR_CT_COLS          DS  XL2
-    GP_VIEW_ID              DS  XL4
-    GP_EXTRACT_VAR_LEN_AREA DS  C
-    *
-            Space 3
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *        Look-Up Key Information
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *
-    GENKEY   DSECT
-    *
-    GP_LOOKUP_KEY  DS  CL128
-    *
-            Space 3
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *        Work Area Ptr Information
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *
-    GENWORK  DSECT
-    *
-    GP_WORK_AREA_ANCHOR DS  A
-    *
-            Space 3
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *        Return Code Information
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *
-    GENRTNC  DSECT
-    *
-    GP_RETURN_CODE DS  A
-    *
-            Space 3
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *        Output Block Ptr Information
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *
-    GENBLOCK DSECT
-    *
-    GP_RESULT_PTR   DS  A
-    *
-            Space 3
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *        Output Block Size Information
-    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    *
-    GENBLKSZ DSECT
-    *
-    GP_RESULT_BLK_SIZE DS F
-    *
+The [Assembler dsects for GenevaERS exit parameter list](this should be a link to the actual source) 
 
 
 
-
-
-
-
- 
 
 # Links
 

--- a/docs/UserExitGuide.md
+++ b/docs/UserExitGuide.md
@@ -1,0 +1,509 @@
+---
+title: GenevaERS User Exit Programming Guide
+nav_order: 1
+---
+
+# User Exit Overview
+
+The [Introduction to User Exit Routines](Intro20-User-Exit_Routines.md) gives an overview of User Exits.  
+
+Exits are a common concept that allows software products to call custom coded programs at specific points to perform functions the tool itself does not do.
+GenevaERS has four major points which can invoke a user exit.  The first three are Extract Phase exits, and are used much more frequently than the Format Phase exit.  They are:
+  - __Read Exits__, which present event file records to GenevaERS threads for processing.  It is associated with an event LR and the RENX logic table function, and is called each time the event LR records in the input buffer have been processed.
+  - __Lookup Exits__, which accept join parameters and return looked up records in response to individual joins.  These exits can also be used as simple function calls.  It is associated with a lookup LR and a LUEX logic table function (rather than a LUSM which searches the in memory lookup data), and is called each time a join to that LR is required.  
+  - __Write Exits__, which accept extract records and can manipulate them before being written to extract files.  It is associated with a view or a write statement within a view and the WREX logic table function (rather than WRIN, WRDT, or WRSU functions) and creates the extract record  
+  - __Format Exits__, the only GVBMR88 exit which accept summarized and formatted Format Phase output records prior to being written to files.  It is associated with a view that is assigned to the Format Phase.  Format exits are very similar to write exits, except that the record being dealt with is the final output record, rather than the extract record.  Because of its infrequent use, we won’t describe this exit in any more detail here.
+
+# Sample User Exits and Relative Exit Complexities
+
+The following gives a better sense of each exit type, and the complexity and options involved for each one. 
+
+## Read Exit
+In the early days of GenevaERS a sample read exit read the GenevaERS Field Definition file and calculated the start position of each field based upon the lengths of the prior fields in the file, a field not stored on the file.  GenevaERS at the time did not read VSAM files, the format of the Field Definition File, so the Read exit performed this function. THe exit detected a change in the logical record for the fields, and start the running position over at 0.  This allowed GenevaERS to produce reports of its own metadata.
+
+Besides the file format, it was written because this isn’t a function well suited to GenevaERS.  GenevaERS doesn’t do many functions that carry values from one record to the next.  And it doesn’t do any "look ahead" functions, like when the next record in the file determines if the current record should be written.  GenevaERS is built for business event processing, not “set processes” evaluating a set of records.
+
+To use this exit one must create a logical record which matched the output from the read exit.  That output was the 20 fields or so on Field Definition File, plus the new field.  GenevaERS knows nothing about the input to the read exit.  For all GenevaERS knew, the exit could have read 10 different files and combined them all together to make an event file.  It could have added 19 of the fields on to the field before passing it on to GenevaERS.  
+
+The read exit emulates an access method; in other words instead of GenevaERS calling the system BSAM access method to get data from disk, it calls the program name specified.  This means that the program must return the results that an access method would return.   Access methods that read from disks don’t know about the actual length of the data records processed by the program.  Rather their record lengths are blocks.  
+
+This read exit read (using a the standard VSAM access method) and manipulated one Field Definition record at a time.  It could have been created as if the block size was the length of one of my field definition records, perhaps 50 bytes in length.  The block size would equal the Logical Record Length (LRECL).  However, this meant that GenevaERS would be calling the exit each time a new record was needed.  The overhead for calling a subprogram is very high.  GenevaERS has to save its register values before calling, and then they have to be restored before going back.  This CPU time can really add up on a large file.  
+
+Thus a more efficient method is for the read exit to process many Field Definition records as if they had come from disk as one block, and then returning the full block to GenevaERS.  GenevaERS will parse the individual records according to the Logical Record Length, and only return to the read exit when a new block of data is needed.   
+
+This process can make a read exit quite complex to create.
+
+## Lookup Exits 
+
+Look-up exits are probably the easiest to create.  This is because they accept a set of parameters and return a record.  The parameters passed to the lookup exit are whatever values are placed in the fields of the join key.  These can be constants, fields from the event file, or fields from another lookup, including calls to other exits.  The output from the lookup exit is a record that must match the LR for the “reference file” record it is to return.   
+
+Although it appears to a GenevaERS developer as if GenevaERS has taken the keys and performed a search of a reference table to find the appropriate record, the exit may have done no such thing.  In fact, it could do something as simple as reordering the fields passed to it and returning the record.
+
+An early sample lookup exit kept a copy of the key it had been passed in the last call, and compared the key from the current call with that key.  If the keys were the same, then it returned a “not found” condition.  If they were different, it returned a “found” condition.  This exit was called by multiple views, which had selection logic to only include found records. This allowed selection of an event record only once no matter how many views it qualified for.  
+
+Lookup exits have been written to perform math calculations that GenevaERS didn’t do natively.  In fact, before GenevaERS had extract time calculations, a generalized user exit allowed passing two numbers and an operator.  The resulting record contained the results of the math.  Many GenevaERS functions have first appeared as user exits, and were later folded into the main code base.
+
+## Write Exits
+
+Extract exits are called whenever a view is to write an extract record.  The write exit is passed the extract record, and the event record.  It can evaluate these records and determine if it was to: 
+  -	Tell GenevaERS to write a record the exit specifies (could be any record) and continue with event file processing.
+  -	Tell GenevaERS to skip this extract record and go on
+  -	Tell GenevaERS to write a record the exit specifies (could be any record) and return to the exit to do more processing.
+
+The exit can manipulate the exit record; substitute a new record, table the extract record in some way and then dump the table at the end of event file processing, among others.  Note, though, that unlike read exits which open and actually read files, write exits typically do not.  They return records to GenevaERS to write to the extract file.  They could do their own IO, but there is typically no benefit to doing so.  GenevaERS’s write routines are very efficient.  
+
+Write exits are in between read and lookup exits for complexity.  This is mainly because of the complexity of dealing with extract records.  The exit must know what the extract record will look like for a particular view.  This might be easiest to determine by actually writing the view, and inspecting the extracted records to find positions and lengths.  Any changes in the views can create a new to update the write exit.  Write exits outputs typically have nothing to do with LRs.  
+
+[Extract Time Summarization](Intro18-ETS_and_Other_Functions.md) made its first appearance as a write exit.  The exit was called on each extract record.  The exit allocated its own memory space, and built a stack of summarized event records.  Only if the extract record caused the exit to overflow the stack did the exit tell GenevaERS to write a record.  When the thread has finished processing, on the last call to the write exit, the write exit would loop through the stack and instruct GenevaERS to write each record in the stack and return to it for additional processing until the internal table was empty.
+
+## Calling and Parameter Overview
+
+Each exit receives a set of static parameters that do not change throughout event file processing.  These can be used to further generalize an exit.
+
+For example, the small lookup exit described above accepted a set of static parameters that described how long the passed key was from the join.  It would use this length to determine what length of data to store and compare.  In this way, this same exit could be used on multiple joins with different keys, from 5 bytes to 50 bytes, regardless of whether the key was composed of 1 field or 50.  This same approach was used by the calculation exit so that it could work with different sizes of numbers being passed to it, and different arithmetic functions. 
+
+Each exit is called:
+ - Once before event file processing begins so it can initialize memory and set up shop. 
+ - Multiple times during processing, depending on the exit type (per block of data required for read exits, for each lookup, or for each extract record to be written) 
+ - One time after event file processing is complete to perform clean up.  The purpose of these calls are indicated to the exit through a phase code.
+
+# Calling Parameters
+
+The GenevaERS Performance Engine Extract Engine (GVBMR95) uses a standard call parameter list when invoking user exits.  This structure is passed to user exits by MR95 (and other custom GenevaERS processes like XRCK the common key buffering process) to pass data (where applicable) and return codes back to MR95 via this structure.  
+
+Below are the COBOL and Assembler versions of the Structures (copybooks) with explanations of the individual fields above the corresponding field.  
+
+##  Environment Data
+
+### X95PARM1-ENV-DATA. 
+
+The Value of X95PARM1-ENV-DATA Is Passed From GVBMR95.  
+
+    01  X95PARM1-ENV-DATA. 
+      05  X95PARM1-THREAD-NBR         PIC S9(04)  COMP.
+      05  X95PARM1-PHASE-CODE         PIC  X(02).
+          88  X95PARM1-OPEN-PHASE     VALUE 'OP'.
+          88  X95PARM1-READ-PHASE     VALUE 'RD'.
+          88  X95PARM1-CLOSE-PHASE    VALUE 'CL'.
+      05  X95PARM1-CURRENT-VIEW-ID    PIC S9(09)  COMP.
+      05  X95PARM1-ENV-VAR-TABLE-PTR  POINTER.
+      05  X95PARM1-JOIN-STEP-COUNT    PIC S9(09)  COMP.
+      05  X95PARM1-JOIN-STACK-PTR     POINTER.
+      05  X95PARM1-PROCESS-DATE-TIME.
+          10  X95PARM1-PROCESS-DATE   PIC  X(08).
+          10  X95PARM1-PROCESS-TIME   PIC  X(08).
+      05  X95PARM1-ERROR-REASON       PIC S9(08)  COMP.
+      05  X95PARM1-ERROR-BUFFER-PTR   POINTER.
+      05  X95PARM1-ERROR-BUFFER-LEN   PIC S9(08)  COMP.
+
+Specifics of each field are below.  
+
+The Thread Number is the number of the thread (the event file number) being processed.
+
+      05  X95PARM1-THREAD-NBR         PIC S9(04)  COMP.
+
+The Phase Code defines what type of call to the exit is being executed in this instance. 
+
+      05  X95PARM1-PHASE-CODE         PIC  X(02).
+          88  X95PARM1-OPEN-PHASE     VALUE 'OP'.
+          88  X95PARM1-READ-PHASE     VALUE 'RD'.
+          88  X95PARM1-CLOSE-PHASE    VALUE 'CL'.
+
+- Open is a call to the exit the first time, before event file record processing begins
+- Read is on each call to the exit during event file record processing
+- Close is after event file record processing has finished.
+
+The View ID is the view calling the exit.  This parameter is not applicable for Read Exits
+
+      05  X95PARM1-CURRENT-VIEW-ID    PIC S9(09)  COMP.
+
+The following need greater definition here in this document. 
+
+      05  X95PARM1-ENV-VAR-TABLE-PTR  POINTER.
+      05  X95PARM1-JOIN-STEP-COUNT    PIC S9(09)  COMP.
+      05  X95PARM1-JOIN-STACK-PTR     POINTER.
+
+The Process Date and Time is the start-up time of the Extract Phase process.
+
+      05  X95PARM1-PROCESS-DATE-TIME.
+          10  X95PARM1-PROCESS-DATE   PIC  X(08).
+          10  X95PARM1-PROCESS-TIME   PIC  X(08).
+
+The Error Reason code gives some description of why the process was aborted. 
+
+      05  X95PARM1-ERROR-REASON       PIC S9(08)  COMP.
+
+The Error Buffer pointer and length fields allow for indicative data that caused the error to be printed in GVBMR95 control and run-time messages.  
+
+      05  X95PARM1-ERROR-BUFFER-PTR   POINTER.
+      05  X95PARM1-ERROR-BUFFER-LEN   PIC S9(08)  COMP.
+
+### X95PARM2-EVENT-FILE-DATA.
+
+The Event File structure gives the view data relative to the event file being processed by this thread.
+
+    01  X95PARM2-EVENT-FILE-DATA.
+        05  X95PARM2-EVENT-DDNAME       PIC  X(08).
+        05  X95PARM2-EVENT-REC-NBR      PIC S9(11)  COMP-3.
+        05  X95PARM2-EVENT-REC-FMT      PIC  X(01).
+            88  X95PARM2-FIXED-LENGTH       VALUE 'F'.
+            88  X95PARM2-VARIABLE-LENGTH    VALUE 'V'.
+            88  X95PARM2-DELIMITED          VALUE 'D'.
+        05  X95PARM2-REC-FLD-DELIM      PIC  X(01).
+        05  X95PARM2-EVENT-REC-LEN      PIC S9(09)  COMP.
+        05  X95PARM2-MAX-REC-LEN        PIC S9(09)  COMP.
+        05  X95PARM2-MAX-BLOCK-SIZE     PIC S9(09)  COMP.
+
+Specifics of each field are below.  
+
+The Value Of X95PARM2-EVENT-DDNAME Is Passed From GVBMR95.  This is the Event File DD Name of the thread being processed.
+
+     05  X95PARM2-EVENT-DDNAME       PIC  X(08).
+
+The Value Of X95PARM2-EVENT-REC-NBR Is Passed From GVBMR95.  This is the event file record number that is currently being processed.
+
+     05  X95PARM2-EVENT-REC-NBR      PIC S9(11)  COMP-3.
+
+Read Exits set the value of X95PARM2-EVENT-REC-FMT in the Open Phase and pass it to GVBMR95.  GVBMR95 passes the value to Lookup Exits And Write Exits, representing the format of the event file being processed by this thread, for this and the following parameters.
+
+     05  X95PARM2-EVENT-REC-FMT      PIC  X(01).
+         88  X95PARM2-FIXED-LENGTH       VALUE 'F'.
+         88  X95PARM2-VARIABLE-LENGTH    VALUE 'V'.
+         88  X95PARM2-DELIMITED          VALUE 'D'.
+
+Read Exits set the value of X95PARM2-REC-FLD-DELIM in the Open Phase and pass it to GVBMR95.  GVBMR95 passes the value to Lookup Exits and Write Exits.
+
+     05  X95PARM2-REC-FLD-DELIM      PIC  X(01).
+
+Read Exits set the value of X95PARM2-Event-Rec-Len on every execution and pass it to GVBMR95.  GVBMR95 passes the value to Lookup Exits and Write Exits.
+
+     05  X95PARM2-EVENT-REC-LEN      PIC S9(09)  COMP.
+
+Read Exits set the value of X95PARM2-Max-Rec-Len in the Open Phase and pass it to GVBMR95.  GVBMR95 passes the value to Lookup Exits and Write Exits.
+
+     05  X95PARM2-MAX-REC-LEN        PIC S9(09)  COMP.
+
+Read Exits set the value of X95PARM2-Max-Block-Size in the Open Phase and pass it to GVBMR95.  GVBMR95 passes the value to Lookup Exits and Write Exits.
+
+     05  X95PARM2-MAX-BLOCK-SIZE     PIC S9(09)  COMP.
+
+## Variable Start-Up Parameters
+
+### X95PARM3-STARTUP-DATA
+
+The layout of X95PARM3-Startup-Data is defined by the GenevaERS configuration for the specific processes involved.  So the structure of the record layout is dependent upon the record layouts (LRs) the GenevaERS configuration.  The startup data values are constant throughout event file record processing.
+
+These parameters can be used to generalize an exit to be used for more GenevaERS processes, for example telling the exit to perform a set of functions when called in this context throughout this GenevaERS processing.  For example, a single lookup exit might do multiple mathematical functions, and the function to be performed each time it is called for a specific lookup logical record could be specified as a start-up parameter. 
+
+The structure and values to be passed to each exit for each type of exit are set in the workbench in the following location:
+
+- For Read Exits, in the Physical File Entity. 
+- For Lookup Exits, in the Logical Record Entity when the lookup exit is specified. 
+- For Write Exits, in the View Properties Or On The Write Verb in the View Logic Text. 
+
+These values are passed to the Exit Program from GVBMR95.
+
+    01  X95PARM3-STARTUP-DATA           PIC  X(32).
+
+When the exit is first called (the Open Phase call) the exit needs to point the record layout inside your program (in the example below the Ls-Startup-Parms)to the location of value passed as X95PARM3-Startup-Data by executing the statement:
+
+`Set Address Of Ls-Startup-Parms To Address Of X95PARM3-Startup-Data`
+
+## Event, Extract and Lookup Record Parameters
+
+### X95PARM4-EVENT-REC
+
+X95PARM4-Event-Rec is not applicable to Read Exits. For Lookup and Write Exits, this parameter points to the current record from the Event File.
+
+Like the Start-up data, the structure of the event file record is dependent upon the specific GenevaERS processing being performed. 
+
+    01  X95PARM4-EVENT-REC              PIC  X(01).
+
+To point your exits definition of the event file record (for this example, Ls-Event-Rec) to the address of the data contained i X95PARM4-Event-Rec execute the statement:
+
+`Set Address Of Ls-Event-Rec To Address Of X95PARM4-Event-Rec`
+
+Do this whenever this program is given control as the location of the event file record changes on each call to the exit.
+
+### X95PARM5-EXTRACT-REC
+
+Like the Event File Record structure, X95PARM5-Extract-Rec is not applicable to Read Exits. For Lookup and Write Exits, this parameter points to the current Extract Record.  
+
+The layout of the beginning of each extract record is fixed as outlined in [Introduction to Format Phase Views](Intro17_Format_Phase_Views.md), but the layout of the rest of the record is determined by the view.  The following is the structure of the fixed portion of the record:
+
+    01  X95PARM5-EXTRACT-REC.
+        05  X95PARM5-EXTRACT-RDW.
+            10  X95PARM5-EXT-REC-LENGTH     PIC S9(04)  COMP.
+            10  FILLER                      PIC S9(04)  COMP.
+        05  X95PARM5-EXTRACT-PREFIX.
+            10  X95PARM5-SORT-KEY-LENGTH    PIC S9(04)  COMP.
+            10  X95PARM5-TITLE-KEY-LENGTH   PIC S9(04)  COMP.
+            10  X95PARM5-DATA-AREA-LENGTH   PIC S9(04)  COMP.
+            10  X95PARM5-NBR-CT-COLS        PIC S9(04)  COMP.
+            10  X95PARM5-VIEW-ID            PIC S9(09)  COMP.
+        05  X95PARM5-EXTRACT-VAR-LEN-AREA   PIC  X(01).
+
+To point your exits copybook structure (for this example, Ls-Extract-Data) to the address of the data contained in X95PARM5-Var-Len-Area execute the statement whenever this program is given control:
+
+`Set Address Of Ls-Extract-Rec To Address Of X95PARM5-Extract-Var-Len-Area`
+
+
+### X95PARM6-LOOKUP-KEY
+
+Like the prior parameters, the layout of X95PARM6-Lookup-Key is dependent upon the GenevaERS processes being run, and the metadata defining them.  For Read and Write Exits this parameter is not applicable. 
+
+For Lookup Exits the structure is set in the View Logic Text or in Join Step Parameters. The values are populated by the logic table LK rows. This value is passed to the exit program from GVBMR95.
+
+    01  X95PARM6-LOOKUP-KEY             PIC  X(256).
+
+To point your program's copybooks structure (in this example, Ls-Lookup-Parms) to the address of the data contained in X95PARM6-Lookup-Key execute the statement whenever this program is given control:
+
+`Set Address Of Ls-Lookup-Parms To Address Of X95PARM6-Lookup-Key`
+
+## Working Storage
+
+### X95PARM7-WORK-AREA-ANCHOR
+GVBMR95 does not guarantee that working storage in a COBOL program will be remain in the same state on subsequent calls to the program, so any data items which need to be retained between calls should be placed in a dynamically allocated area, and the address of that area stored in this pointer, which will be returned by GVBMR95 on each subsequent call.
+
+ 01  X95PARM7-WORK-AREA-ANCHOR       POINTER.
+
+During the open phase, the GenevaERS routine GVBUR05 should be called to allocate a work area (in this example, LS-Work-Area) and X95PARM7-WORK-AREA-ANCHOR should be set to point to it.  For example:
+
+`Move Length Of Ls-Work-Area To Ws-Work-Area-Length`
+
+`Call GVBUR05 Using X95PARM7-Work-Area-Anchor Ws-Work-Area-Length`
+
+`Set Address Of Ls-Work-Area To X95PARM7-Work-Area-Anchor`
+
+On Subsequent Calls, X95PARM7-WORK-AREA-ANCHOR retains its value and may be pointed to the structure again, by using:
+
+`Set Address Of Ls-Work-Area To X95PARM7-Work-Area-Anchor`
+
+## Return Code and Result Set
+
+### X95PARM8-RETURN-CODE
+X95PARM8-Return-Code should be set in the exit program to the numeric code to be returned to GVBMR95.
+
+      01  X95PARM8-RETURN-CODE            PIC S9(09)  COMP.
+      *  All Exits:
+          88  X95PARM8-SUCCESSFUL             VALUE +0.
+      *  Lookup Exits Only:
+          88  X95PARM8-NOT-FOUND              VALUE +4.
+      *  Write Exits Only:
+          88  X95PARM8-WRITE-AND-REPEAT-CALL  VALUE +4.
+      *  READ EXITS ONLY:
+          88  X95PARM8-END-OF-FILE            VALUE +8.
+      *  LOOKUP EXITS ONLY:
+          88  X95PARM8-SKIP-EVENT-REC         VALUE +8.
+      *  WRITE EXITS ONLY:
+          88  X95PARM8-SKIP-EXTRACT-REC       VALUE +8.
+      *  ALL EXITS:
+          88  X95PARM8-DISABLE-CURRENT-VIEW   VALUE +12.
+          88  X95PARM8-ABORT-RUN              VALUE +16.
+
+__Lookup Exits__:
+- _Lookup Found+_:  A return value of +0 signals GVBMR95 that the lookup exit successfully returned a result that can be used by the view.
+- _Lookup Not Found_:  Alternatively a return code value of +4 signals GVBMR95 that no successful result was returned, so the view should use the Not Found condition.
+- _Lookup Skip Event File Record_: A +8 signals GVBMR95 that the view should completely bypass further processing of the event file record.  This means execution continues with the next view, so no extract record will be written for the view for this record, but the view is not disabled from processing future records (see Disabled below).
+
+__Write Exits__:
+- _Write Extract Record_:  A return value of +0 signals GVBMR95 to write the record returned by the Write Exit to the extract file.
+- _Write and Repeat Call_: A return code of +4 signals GVBMR95 to write the record returned by the Write Exit, and then return to the Write Exit for further processing.  This return code was used by the initial Extract Time Summarization write exit to dump all tabled records to the extract file at the conclusion of processing in the Close Phase with the last call being a +0 return code.
+- _Skip Extract Record_:  A return code of +8 signals GVBMR95 that no extract record should be written after this call, and processing should continue to the next logic table function.
+
+__Read Exits__: 
+- _Process Buffer_:  A return code of +0 signals GVBMR95 to process the buffer returned by the Read Exit through the views.  
+- _End of File_:  A return code of +8 signals GVBMR95 that end of file has been reached by the read exit; GVBMR95 should move to the Close Phase.
+
+
+__Error Processing__
+- _Disable Current View_:  Only applicable for Lookup and Write Exits, (Not Read Exits, which are not view specific) a return code of +12 signals GVBMR95 to disable the view for further processing.  Although extract records have been written to the output file, no further records will be written.  The control report will signal a view was disabled.  If the view is a Format Phase View, the extract records will be skipped and no output will be produced.  GenevaERS cannot stop automatically downstream non-extract file processing, but GenevaERS facilities can be used to build processes to detect disabled views.
+- _Abort Processing_:  A return code of +16 signals GVBMR95 to immediately stop all processing.
+
+The X95PARM1-ERROR-REASON (in the PARM1 structure) can be populated for either the disable view or abort run return values.  This value will be printed in the z/OS Message Logs, along with the indicative data pointed to by the error buffer pointer.
+
+### X95PARM9-RESULT-PTR and X95PARMA-RESULT-BLOCK-SIZE
+
+Like Exit Working Storage, memory for the result sets are not provided by GVBMR95. Exits are responsible for allocations of this memory. X95PARM9-RESULT-PTR should be set in the exit program to the address of the structure to be returned to GVBMR95. 
+
+     01  X95PARM9-RESULT-PTR             POINTER.
+
+The values and structures returned in this area must match the LRs defined for them, for either Look-up or Read Exits. 
+
+Because Write Exit create only extract record typically written directly to extract files and not subject to further view processing, they may not have this requirement.  If the view results are piped to another set of views, they may also need to match the describing LRs.  
+
+To point X95PARM9-Result-Ptr to your own structure (in this example, Ws-Result), execute the statement whenever this program is given control:
+
+`Set X95PARM9-Result-Ptr To Address Of Ws-Result`
+
+_Lookup Exits Only_:  Though Optional, it is a good exit programming practice to move -1 to X95PARM9-Result-Ptr-Numeric when the lookup result is "Not Found".  This guarantees that the pointer is no longer pointing to valid data.
+
+    01  X95PARM9-RESULT-PTR-NUMERIC     REDEFINES
+        X95PARM9-RESULT-PTR             PIC S9(09)  COMP.
+
+_Read Exits Only_: During the Open Phase, Read Exits should return the first event record block. 
+
+Read Exits should set the value of X95PARMa-Result-Block-Size to the length of the block pointed to by X95PARM9-Result-Ptr.
+
+    01  X95PARMA-RESULT-BLOCK-SIZE      PIC S9(09)  COMP.
+
+END X95PARMA-RESULT-BLOCK-SIZE
+
+# ASSEMBLER VERSION GVBX95PA
+
+The following are the structures if z/OS Assembler is used for the exit.
+
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *                                                                     *
+    *        GenevaERS Provided Parameter List 
+    *                                                                     *
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *
+    GENPARM  DSECT                  GenevaERS  PARAMETER LIST
+    *
+    GPENVA   DS    AL04             ENVIRONMENT  INFO ADDR
+    GPFILEA  DS    AL04             FILE         INFO ADDR
+    GPSTARTA DS    AL04             STARTUP      DATA ADDR
+    GPEVENTA DS    AL04             EVENT      RECORD ADDR      (N/A)
+    GPEXTRA  DS    AL04             EXTRACT    RECORD ADDR      (N/A)
+    GPKEYA   DS    AL04             LOOK-UP    KEY    ADDR      (N/A)
+    GPWORKA  DS    AL04             WORK AREA POINTER ADDR
+    *
+    GPRTNCA  DS    AL04             RETURN CODE       ADDR
+    GPBLOCKA DS    AL04             OUTPUT BLOCK PTR  ADDR
+    GPBLKSIZ DS    AL04             OUTPUT BLOCK SIZE ADDR
+            SPACE 3
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *        Environment Information
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *
+    GENENV   DSECT                  ENVIRONMENT INFORMATION
+    *
+    GPTHRDNO DS    HL02             CURRENT THREAD   NUMBER
+    GPPHASE  DS    CL02             CURRENT EXECUTION PHASE
+    GPVIEW#  DS    FL04             CURRENT EXECUTING  VIEW
+    GPENVVA  DS    AL04             ENV VARIABLE TABLE ("MR95ENVV") ADDR
+    GPJSTPCT DS    FL04             JOIN STEP COUNT
+    GPJSTKA  DS    AL04             JOIN STACK ADDRESS
+    GP_PROCESS_DATE_TIME DS 0XL16   Process Date and time
+    GP_PROCESS_DATE      DS  XL8    Date
+    GP_PROCESS_TIME      DS  XL8    Time
+    GP_ERROR_REASON      DS  FL04   Error reason code
+    GP_ERROR_BUFFER_PTR  DS  AL04   -> error text
+    GP_ERROR_BUFFER_LEN  DS  FL04   To exit - set to length of buffer
+    *                               from exit - set to text length
+            Space 3
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *        File Information
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *
+    GENFILE  DSECT                  EVENT FILE   INFORMATION
+    *
+    GPDDNAME DS    CL08             EVENT  FILE  DDNAME
+    GPRECCNT DS    PL06             EVENT  FILE  RECORD COUNT
+    GPRECFMT DS    CL01             RECORD FORMAT  (F,V,D)
+    GPRECDEL DS    CL01             RECORD DELIMITER
+    GPRECLEN DS    FL04             RECORD LEN   CURRENT
+    GPRECMAX DS    FL04             RECORD LEN   MAXIMUM
+    GPBLKMAX DS    FL04             BLOCK  SIZE  MAXIMUM
+    *
+            Space 3
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *        Startup Data Information
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *
+    GENSTART DSECT
+    *
+    GP_STARTUP_DATA DS CL32
+    *
+            Space 3
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *        Event Record Information
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *
+    GENEVENT DSECT
+    *
+    GP_EVENT_REC    DS C
+    *
+            Space 3
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *        Extract Record Information
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *
+    GENEXTR  DSECT
+    *
+    GP_EXTRACT_REC          DS  0CL17
+    GP_EXTRACT_RDW          DS  0XL4
+    GP_EXT_REC_LENGTH       DS  XL2
+                            DS  XL2
+    GP_EXTRACT_PREFIX       DS  0CL12
+    GP_SORT_KEY_LENGTH      DS  XL2
+    GP_TITLE_KEY_LENGTH     DS  XL2
+    GP_DATA_AREA_LENGTH     DS  XL2
+    GP_NBR_CT_COLS          DS  XL2
+    GP_VIEW_ID              DS  XL4
+    GP_EXTRACT_VAR_LEN_AREA DS  C
+    *
+            Space 3
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *        Look-Up Key Information
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *
+    GENKEY   DSECT
+    *
+    GP_LOOKUP_KEY  DS  CL128
+    *
+            Space 3
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *        Work Area Ptr Information
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *
+    GENWORK  DSECT
+    *
+    GP_WORK_AREA_ANCHOR DS  A
+    *
+            Space 3
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *        Return Code Information
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *
+    GENRTNC  DSECT
+    *
+    GP_RETURN_CODE DS  A
+    *
+            Space 3
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *        Output Block Ptr Information
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *
+    GENBLOCK DSECT
+    *
+    GP_RESULT_PTR   DS  A
+    *
+            Space 3
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *        Output Block Size Information
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    *
+    GENBLKSZ DSECT
+    *
+    GP_RESULT_BLK_SIZE DS F
+    *
+
+
+
+
+
+
+
+ 
+
+# Links
+
+Place following text in the topic:  
+    ````
+    [Topic A](TopicA)
+    ````
+
+The link displays as:   
+[Topic A](TopicA)


### PR DESCRIPTION
@KipTwitchell here is my review and edits of the user exits docs. Please review. 
I created a new branch from your branch - not sure if that was the best way.
I cut of lot of text that is not relevant in our newer version of GenevaERS, and also most of the diagrams and screen shots were out of date. I also tried to make the terminology consistent with the Workbench; use 'source file' and not 'event file', 'lookup' and not 'join'. I also updated the parm list, but we really need to put the parm lists in the pe repo and link to them.